### PR TITLE
Fix texture(samplerCubeShadow,...) in GL4

### DIFF
--- a/gl4/html/texture.xhtml
+++ b/gl4/html/texture.xhtml
@@ -138,7 +138,7 @@
             </tr>
             <tr>
               <td> </td>
-              <td>vec3 <var class="pdparam">P</var>, </td>
+              <td>vec4 <var class="pdparam">P</var>, </td>
             </tr>
             <tr>
               <td> </td>

--- a/gl4/texture.xml
+++ b/gl4/texture.xml
@@ -58,7 +58,7 @@
             <funcprototype>
                 <funcdef>float <function>texture</function></funcdef>
                 <paramdef>samplerCubeShadow <parameter>sampler</parameter></paramdef>
-                <paramdef>vec3 <parameter>P</parameter></paramdef>
+                <paramdef>vec4 <parameter>P</parameter></paramdef>
                 <paramdef>[float <parameter>bias</parameter>]</paramdef>
             </funcprototype>
             <funcprototype>


### PR DESCRIPTION
See GLSLangSpec.4.50.pdf page 164.
It's correct in the ES 3.1 docs.