### PR TITLE
Fix return type of OpenGL ES 3.x glFramebufferRenderbuffer to match header files

### DIFF
--- a/es3.0/glFramebufferRenderbuffer.xml
+++ b/es3.0/glFramebufferRenderbuffer.xml
@@ -20,7 +20,7 @@
     <refsynopsisdiv><title>C Specification</title>
         <funcsynopsis>
             <funcprototype>
-                <funcdef>GLsync <function>glFramebufferRenderbuffer</function></funcdef>
+                <funcdef>void <function>glFramebufferRenderbuffer</function></funcdef>
                 <paramdef>GLenum <parameter>target</parameter></paramdef>
                 <paramdef>GLenum <parameter>attachment</parameter></paramdef>
                 <paramdef>GLenum <parameter>renderbuffertarget</parameter></paramdef>

--- a/es3.1/glFramebufferRenderbuffer.xml
+++ b/es3.1/glFramebufferRenderbuffer.xml
@@ -21,7 +21,7 @@
         <title>C Specification</title>
         <funcsynopsis>
             <funcprototype>
-                <funcdef>GLsync <function>glFramebufferRenderbuffer</function></funcdef>
+                <funcdef>void <function>glFramebufferRenderbuffer</function></funcdef>
                 <paramdef>GLenum <parameter>target</parameter></paramdef>
                 <paramdef>GLenum <parameter>attachment</parameter></paramdef>
                 <paramdef>GLenum <parameter>renderbuffertarget</parameter></paramdef>

--- a/es3/glFramebufferRenderbuffer.xml
+++ b/es3/glFramebufferRenderbuffer.xml
@@ -21,7 +21,7 @@
         <title>C Specification</title>
         <funcsynopsis>
             <funcprototype>
-                <funcdef>GLsync <function>glFramebufferRenderbuffer</function></funcdef>
+                <funcdef>void <function>glFramebufferRenderbuffer</function></funcdef>
                 <paramdef>GLenum <parameter>target</parameter></paramdef>
                 <paramdef>GLenum <parameter>attachment</parameter></paramdef>
                 <paramdef>GLenum <parameter>renderbuffertarget</parameter></paramdef>


### PR DESCRIPTION
Currently glFramebufferRenderbuffer is listed as returning GLsync in the OpenGL ES 3.0, 3.1, and 3.2 refpages.  This change fixes the return type to be correctly listed as void.