### PR TITLE
Add some missing pnames in glGet variants in es 3.1

### DIFF
--- a/es3.1/glGet.xml
+++ b/es3.1/glGet.xml
@@ -866,6 +866,15 @@
                 </listitem>
             </varlistentry>
             <varlistentry>
+                <term><constant>GL_MAX_DEPTH_TEXTURE_SAMPLES</constant></term>
+                <listitem>
+                    <para>
+                        <parameter>params</parameter> returns one value,
+                        the maximum number of samples in a depth/stencil multisample texture.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
                 <term><constant>GL_MAX_DRAW_BUFFERS</constant></term>
                 <listitem>
                     <para>
@@ -1604,6 +1613,15 @@
                         <parameter>params</parameter> returns a single positive floating-point value indicating the
                         current sample coverage value.
                         See <citerefentry><refentrytitle>glSampleCoverage</refentrytitle></citerefentry>.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><constant>GL_SAMPLE_MASK_VALUE</constant></term>
+                <listitem>
+                    <para>
+                        <parameter>params</parameter> returns one value indicating the current sample mask value.
+                        See <citerefentry><refentrytitle>glSampleMaski</refentrytitle></citerefentry>.
                     </para>
                 </listitem>
             </varlistentry>

--- a/es3/glGet.xml
+++ b/es3/glGet.xml
@@ -1012,6 +1012,15 @@
                 </listitem>
             </varlistentry>
             <varlistentry>
+                <term><constant>GL_MAX_DEPTH_TEXTURE_SAMPLES</constant></term>
+                <listitem>
+                    <para>
+                        <parameter>params</parameter> returns one value,
+                        the maximum number of samples in a depth/stencil multisample texture.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
                 <term><constant>GL_MAX_DRAW_BUFFERS</constant></term>
                 <listitem>
                     <para>
@@ -2194,6 +2203,15 @@
                         <parameter>data</parameter> returns a single positive floating-point value indicating the
                         current sample coverage value.
                         See <citerefentry><refentrytitle>glSampleCoverage</refentrytitle></citerefentry>.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><constant>GL_SAMPLE_MASK_VALUE</constant></term>
+                <listitem>
+                    <para>
+                        <parameter>params</parameter> returns one value indicating the current sample mask value.
+                        See <citerefentry><refentrytitle>glSampleMaski</refentrytitle></citerefentry>.
                     </para>
                 </listitem>
             </varlistentry>


### PR DESCRIPTION
Thanks for your suggestion at https://github.com/KhronosGroup/OpenGL-API/issues/25, Jon. Please take a look at this small change. @oddhack . Thanks!