### PR TITLE
Add some missing pnames in glGet variants in es 3.1 and 3.2

### DIFF
--- a/es3.1/glGet.xml
+++ b/es3.1/glGet.xml
@@ -697,6 +697,14 @@
                 </listitem>
             </varlistentry>
             <varlistentry>
+                <term><constant>GL_MAX_COMBINED_ATOMIC_COUNTER_BUFFERS</constant></term>
+                <listitem>
+                    <para>
+                        <parameter>params</parameter> returns a single value, the maximum number of atomic counter buffers that may be accessed by all active shaders.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
                 <term><constant>GL_MAX_COMBINED_COMPUTE_UNIFORM_COMPONENTS</constant></term>
                 <listitem>
                     <para>
@@ -931,6 +939,15 @@
                 <listitem>
                     <para>
                         <parameter>params</parameter> returns a single value, the maximum number of atomic counters available to fragment shaders.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><constant>GL_MAX_FRAGMENT_ATOMIC_COUNTER_BUFFERS</constant></term>
+                <listitem>
+                    <para>
+                        <parameter>params</parameter> returns a single value, the maximum number of atomic counter buffers that may be accessed by a fragment shader.
+                        In GL ES 3.1, the minimum value is 0.
                     </para>
                 </listitem>
             </varlistentry>
@@ -1216,6 +1233,14 @@
                 <listitem>
                     <para>
                         <parameter>params</parameter> returns a single value, the maximum number of atomic counters available to vertex shaders.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><constant>GL_MAX_VERTEX_ATOMIC_COUNTER_BUFFERS</constant></term>
+                <listitem>
+                    <para>
+                        <parameter>params</parameter> returns a single value, the maximum number of atomic counter buffers that may be accessed by a vertex shader.
                     </para>
                 </listitem>
             </varlistentry>
@@ -2274,10 +2299,13 @@
             <constant>GL_MAX_FRAMGENT_ATOMIC_COUNTERS</constant>,
             <constant>GL_MAX_COMPUTE_ATOMIC_COUNTERS</constant>,
             <constant>GL_MAX_COMBINED_ATOMIC_COUNTERS</constant>,
+            <constant>GL_MAX_VERTEX_ATOMIC_COUNTER_BUFFERS</constant>,
+            <constant>GL_MAX_FRAMGENT_ATOMIC_COUNTER_BUFFERS</constant>,
+            <constant>GL_MAX_COMPUTE_ATOMIC_COUNTER_BUFFERS</constant>,
+            <constant>GL_MAX_COMBINED_ATOMIC_COUNTER_BUFFERS</constant>,
             <constant>GL_MAX_COMPUTE_UNIFORM_BLOCKS</constant>,
             <constant>GL_MAX_COMPUTE_TEXTURE_IMAGE_UNITS</constant>,
             <constant>GL_MAX_COMPUTE_UNIFORM_COMPONENTS</constant>,
-            <constant>GL_MAX_COMPUTE_ATOMIC_COUNTER_BUFFERS</constant>,
             <constant>GL_MAX_COMBINED_COMPUTE_UNIFORM_COMPONENTS</constant>,
             <constant>GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS</constant>,
             <constant>GL_MAX_COMPUTE_WORK_GROUP_COUNT</constant>,

--- a/es3/glGet.xml
+++ b/es3/glGet.xml
@@ -768,6 +768,14 @@
                 </listitem>
             </varlistentry>
             <varlistentry>
+                <term><constant>GL_MAX_COMBINED_ATOMIC_COUNTER_BUFFERS</constant></term>
+                <listitem>
+                    <para>
+                        <parameter>data</parameter> returns a single value, the maximum number of atomic counter buffers that may be accessed by all active shaders.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
                 <term><constant>GL_MAX_COMBINED_COMPUTE_UNIFORM_COMPONENTS</constant></term>
                 <listitem>
                     <para>
@@ -1077,7 +1085,7 @@
                 <listitem>
                     <para>
                         <parameter>data</parameter> returns a single value, the maximum number of atomic counters available to fragment shaders.
-                        In GL ES 3.1, the minimum value is 0. in GL ES 3.2, the minimum value is 8.
+                        In GL ES 3.1, the minimum value is 0. In GL ES 3.2, the minimum value is 8.
                     </para>
                 </listitem>
             </varlistentry>
@@ -1086,7 +1094,7 @@
                 <listitem>
                     <para>
                         <parameter>data</parameter> returns a single value, the maximum number of atomic counter buffers that may be accessed by a fragment shader.
-                        In GL ES 3.1, the minimum value is 0. in GL ES 3.2, the minimum value is 1.
+                        In GL ES 3.1, the minimum value is 0. In GL ES 3.2, the minimum value is 1.
                     </para>
                 </listitem>
             </varlistentry>
@@ -1096,7 +1104,7 @@
                     <para>
                         <parameter>data</parameter> returns one value, the maximum supported number of image variables 
                         in fragment shaders.
-                        In GL ES 3.1, the minimum value is 0. in GL ES 3.2, the minimum value is 4.
+                        In GL ES 3.1, the minimum value is 0. In GL ES 3.2, the minimum value is 4.
                     </para>
                 </listitem>
             </varlistentry>            
@@ -1125,7 +1133,7 @@
                     <para>
                         <parameter>data</parameter> returns one value,
                         the maximum number of active shader storage blocks that may be accessed by a fragment shader.
-                        In GL ES 3.1, the minimum value is 0. in GL ES 3.2, the minimum value is 4.
+                        In GL ES 3.1, the minimum value is 0. In GL ES 3.2, the minimum value is 4.
                     </para>
                 </listitem>
             </varlistentry>
@@ -1727,6 +1735,14 @@
                 <listitem>
                     <para>
                         <parameter>data</parameter> returns a single value, the maximum number of atomic counters available to vertex shaders.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><constant>GL_MAX_VERTEX_ATOMIC_COUNTER_BUFFERS</constant></term>
+                <listitem>
+                    <para>
+                        <parameter>data</parameter> returns a single value, the maximum number of atomic counter buffers that may be accessed by a vertex shader.
                     </para>
                 </listitem>
             </varlistentry>
@@ -2925,10 +2941,13 @@
             <constant>GL_MAX_FRAMGENT_ATOMIC_COUNTERS</constant>,
             <constant>GL_MAX_COMPUTE_ATOMIC_COUNTERS</constant>,
             <constant>GL_MAX_COMBINED_ATOMIC_COUNTERS</constant>,
+            <constant>GL_MAX_VERTEX_ATOMIC_COUNTER_BUFFERS</constant>,
+            <constant>GL_MAX_FRAMGENT_ATOMIC_COUNTER_BUFFERS</constant>,
+            <constant>GL_MAX_COMPUTE_ATOMIC_COUNTER_BUFFERS</constant>,
+            <constant>GL_MAX_COMBINED_ATOMIC_COUNTER_BUFFERS</constant>,
             <constant>GL_MAX_COMPUTE_UNIFORM_BLOCKS</constant>,
             <constant>GL_MAX_COMPUTE_TEXTURE_IMAGE_UNITS</constant>,
             <constant>GL_MAX_COMPUTE_UNIFORM_COMPONENTS</constant>,
-            <constant>GL_MAX_COMPUTE_ATOMIC_COUNTER_BUFFERS</constant>,
             <constant>GL_MAX_COMBINED_COMPUTE_UNIFORM_COMPONENTS</constant>,
             <constant>GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS</constant>,
             <constant>GL_MAX_COMPUTE_WORK_GROUP_COUNT</constant>,


### PR DESCRIPTION
The missing pnames are related to atomic counter.

PTAL. Thank you very much.