### PR TITLE
Use `constant` tag for `GL_TEXTURE_CUBE_MAP_ARRAY`

### DIFF
--- a/gl4/glGetTexImage.xml
+++ b/gl4/glGetTexImage.xml
@@ -78,7 +78,7 @@
           <constant>GL_TEXTURE_CUBE_MAP_NEGATIVE_Y</constant>,
           <constant>GL_TEXTURE_CUBE_MAP_POSITIVE_Z</constant>,
           <constant>GL_TEXTURE_CUBE_MAP_NEGATIVE_Z</constant>, and
-          <code>GL_TEXTURE_CUBE_MAP_ARRAY</code> are acceptable.</para>
+          <constant>GL_TEXTURE_CUBE_MAP_ARRAY</constant> are acceptable.</para>
         </listitem>
       </varlistentry>
 

--- a/gl4/html/glGetTexImage.xhtml
+++ b/gl4/html/glGetTexImage.xhtml
@@ -139,7 +139,7 @@
           <code class="constant">GL_TEXTURE_CUBE_MAP_NEGATIVE_Y</code>,
           <code class="constant">GL_TEXTURE_CUBE_MAP_POSITIVE_Z</code>,
           <code class="constant">GL_TEXTURE_CUBE_MAP_NEGATIVE_Z</code>, and
-          <code class="code">GL_TEXTURE_CUBE_MAP_ARRAY</code> are acceptable.</p>
+          <code class="constant">GL_TEXTURE_CUBE_MAP_ARRAY</code> are acceptable.</p>
             </dd>
             <dt>
               <span class="term">


### PR DESCRIPTION
`<constant>` should be used instead of `<code>` to be consistent with the other targets.