### PR TITLE
Fix typos in GL4 trunc/round purpose/description

### DIFF
--- a/gl4/round.xml
+++ b/gl4/round.xml
@@ -15,7 +15,7 @@
     </refmeta>
     <refnamediv>
         <refname>round</refname>
-        <refpurpose>find the nearest integer less than or equal to the parameter</refpurpose>
+        <refpurpose>find the nearest integer to the parameter</refpurpose>
     </refnamediv>
     <refsynopsisdiv><title>Declaration</title>
         <funcsynopsis>

--- a/gl4/trunc.xml
+++ b/gl4/trunc.xml
@@ -15,7 +15,7 @@
     </refmeta>
     <refnamediv>
         <refname>trunc</refname>
-        <refpurpose>find the nearest integer less than or equal to the parameter</refpurpose>
+        <refpurpose>find the truncated value of the parameter</refpurpose>
     </refnamediv>
     <refsynopsisdiv><title>Declaration</title>
         <funcsynopsis>


### PR DESCRIPTION
Corrected to use the right purpose text (as opposed to that from `floor`).