### PR TITLE
Fix issue #54

### DIFF
--- a/gl4/glGet.xml
+++ b/gl4/glGet.xml
@@ -1,4 +1,4 @@
-<!DOCTYPE refentry [ <!ENTITY % mathent SYSTEM "math.ent"> %mathent; ]>
+﻿<!DOCTYPE refentry [ <!ENTITY % mathent SYSTEM "math.ent"> %mathent; ]>
 
 <!-- Converted by db4-upgrade version 1.1 -->
 
@@ -2536,6 +2536,15 @@
                 </listitem>
             </varlistentry>
             <varlistentry>
+                <term><constant>GL_VERTEX_BINDING_BUFFER</constant></term>
+                <listitem>
+                    <para>
+                        Accepted by the indexed forms. <parameter>data</parameter> returns a single integer value representing the name of the buffer
+                        bound to vertex binding <parameter>index</parameter>.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
                 <term><constant>GL_MAX_VERTEX_ATTRIB_RELATIVE_OFFSET</constant></term>
                 <listitem>
                     <para>
@@ -2697,7 +2706,7 @@
             <constant>GL_TEXTURE_BUFFER_OFFSET_ALIGNMENT</constant> is available only if the GL version is 4.3 or greater.
         </para>
         <para>
-            <constant>GL_VERTEX_BINDING_DIVISOR</constant>, <constant>GL_VERTEX_BINDING_OFFSET</constant>, <constant>GL_VERTEX_BINDING_STRIDE</constant>,
+            <constant>GL_VERTEX_BINDING_DIVISOR</constant>, <constant>GL_VERTEX_BINDING_OFFSET</constant>, <constant>GL_VERTEX_BINDING_STRIDE</constant>, <constant>GL_VERTEX_BINDING_BUFFER</constant>,
             <constant>GL_MAX_VERTEX_ATTRIB_RELATIVE_OFFSET</constant> and <constant>GL_MAX_VERTEX_ATTRIB_BINDINGS</constant> are available only if
             the GL version is 4.3 or greater.
         </para>

--- a/gl4/glGetVertexAttrib.xml
+++ b/gl4/glGetVertexAttrib.xml
@@ -1,4 +1,4 @@
-<!DOCTYPE refentry [ <!ENTITY % mathent SYSTEM "math.ent"> %mathent; ]>
+﻿<!DOCTYPE refentry [ <!ENTITY % mathent SYSTEM "math.ent"> %mathent; ]>
 
 <!-- Converted by db4-upgrade version 1.1 -->
 
@@ -88,7 +88,10 @@
             <constant>GL_VERTEX_ATTRIB_ARRAY_TYPE</constant>,
             <constant>GL_VERTEX_ATTRIB_ARRAY_NORMALIZED</constant>,
             <constant>GL_VERTEX_ATTRIB_ARRAY_INTEGER</constant>,
-            <constant>GL_VERTEX_ATTRIB_ARRAY_DIVISOR</constant>, or
+            <constant>GL_VERTEX_ATTRIB_ARRAY_LONG</constant>,
+            <constant>GL_VERTEX_ATTRIB_ARRAY_DIVISOR</constant>, 
+            <constant>GL_VERTEX_ATTRIB_BINDING</constant>,
+            <constant>GL_VERTEX_ATTRIB_RELATIVE_OFFSET</constant> or
             <constant>GL_CURRENT_VERTEX_ATTRIB</constant>.</para>
         </listitem>
         </varlistentry>
@@ -213,6 +216,18 @@
             0 (<constant>GL_FALSE</constant>).</para>
         </listitem>
         </varlistentry>
+        
+        <varlistentry>
+        <term><constant>GL_VERTEX_ATTRIB_ARRAY_LONG</constant></term>
+        <listitem>
+                <para>
+                </para>
+            <para> <parameter>param</parameter> returns a single value that is non-zero
+	          (true) if a vertex attribute is stored as an unconverted double, and
+	          0 (false) otherwise. The initial value is 0
+	          (<constant>GL_FALSE</constant>).</para>
+        </listitem>
+        </varlistentry>
 
         <varlistentry>
         <term><constant>GL_VERTEX_ATTRIB_ARRAY_DIVISOR</constant></term>
@@ -223,6 +238,29 @@
             single value that is the frequency divisor used for instanced
             rendering. See <citerefentry><refentrytitle>glVertexAttribDivisor</refentrytitle></citerefentry>.
             The initial value is 0.</para>
+        </listitem>
+        </varlistentry>
+        
+        <varlistentry>
+        <term><constant>GL_VERTEX_ATTRIB_BINDING</constant></term>
+        <listitem>
+                <para>
+                </para>
+            <para> <parameter>params</parameter> returns a
+            single value, the vertex buffer binding of the vertex attribute array
+            <parameter>index</parameter>.</para>
+        </listitem>
+        </varlistentry>
+
+        <varlistentry>
+        <term><constant>GL_VERTEX_ATTRIB_RELATIVE_OFFSET</constant></term>
+        <listitem>
+                <para>
+                </para>
+            <para> <parameter>params</parameter> returns a single value that is the byte
+	          offset of the first element relative to the start of the vertex
+	          buffer binding specified attribute fetches from. The initial value
+	          is 0.</para>
         </listitem>
         </varlistentry>
 

--- a/gl4/html/glGet.xhtml
+++ b/gl4/html/glGet.xhtml
@@ -3084,6 +3084,17 @@
             </dd>
             <dt>
               <span class="term">
+                <code class="constant">GL_VERTEX_BINDING_BUFFER</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                        Accepted by the indexed forms. <em class="parameter"><code>data</code></em> returns a single integer value representing the name of the buffer
+                        bound to vertex binding <em class="parameter"><code>index</code></em>.
+                    </p>
+            </dd>
+            <dt>
+              <span class="term">
                 <code class="constant">GL_MAX_VERTEX_ATTRIB_RELATIVE_OFFSET</code>
               </span>
             </dt>
@@ -3260,7 +3271,7 @@
             <code class="constant">GL_TEXTURE_BUFFER_OFFSET_ALIGNMENT</code> is available only if the GL version is 4.3 or greater.
         </p>
         <p>
-            <code class="constant">GL_VERTEX_BINDING_DIVISOR</code>, <code class="constant">GL_VERTEX_BINDING_OFFSET</code>, <code class="constant">GL_VERTEX_BINDING_STRIDE</code>,
+            <code class="constant">GL_VERTEX_BINDING_DIVISOR</code>, <code class="constant">GL_VERTEX_BINDING_OFFSET</code>, <code class="constant">GL_VERTEX_BINDING_STRIDE</code>, <code class="constant">GL_VERTEX_BINDING_BUFFER</code>,
             <code class="constant">GL_MAX_VERTEX_ATTRIB_RELATIVE_OFFSET</code> and <code class="constant">GL_MAX_VERTEX_ATTRIB_BINDINGS</code> are available only if
             the GL version is 4.3 or greater.
         </p>

--- a/gl4/html/glGetVertexAttrib.xhtml
+++ b/gl4/html/glGetVertexAttrib.xhtml
@@ -163,7 +163,10 @@
             <code class="constant">GL_VERTEX_ATTRIB_ARRAY_TYPE</code>,
             <code class="constant">GL_VERTEX_ATTRIB_ARRAY_NORMALIZED</code>,
             <code class="constant">GL_VERTEX_ATTRIB_ARRAY_INTEGER</code>,
-            <code class="constant">GL_VERTEX_ATTRIB_ARRAY_DIVISOR</code>, or
+            <code class="constant">GL_VERTEX_ATTRIB_ARRAY_LONG</code>,
+            <code class="constant">GL_VERTEX_ATTRIB_ARRAY_DIVISOR</code>, 
+            <code class="constant">GL_VERTEX_ATTRIB_BINDING</code>,
+            <code class="constant">GL_VERTEX_ATTRIB_RELATIVE_OFFSET</code> or
             <code class="constant">GL_CURRENT_VERTEX_ATTRIB</code>.</p>
             </dd>
             <dt>
@@ -302,6 +305,19 @@
             </dd>
             <dt>
               <span class="term">
+                <code class="constant">GL_VERTEX_ATTRIB_ARRAY_LONG</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                </p>
+              <p> <em class="parameter"><code>param</code></em> returns a single value that is non-zero
+	          (true) if a vertex attribute is stored as an unconverted double, and
+	          0 (false) otherwise. The initial value is 0
+	          (<code class="constant">GL_FALSE</code>).</p>
+            </dd>
+            <dt>
+              <span class="term">
                 <code class="constant">GL_VERTEX_ATTRIB_ARRAY_DIVISOR</code>
               </span>
             </dt>
@@ -312,6 +328,31 @@
             single value that is the frequency divisor used for instanced
             rendering. See <a class="citerefentry" href="glVertexAttribDivisor.xhtml"><span class="citerefentry"><span class="refentrytitle">glVertexAttribDivisor</span></span></a>.
             The initial value is 0.</p>
+            </dd>
+            <dt>
+              <span class="term">
+                <code class="constant">GL_VERTEX_ATTRIB_BINDING</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                </p>
+              <p> <em class="parameter"><code>params</code></em> returns a
+            single value, the vertex buffer binding of the vertex attribute array
+            <em class="parameter"><code>index</code></em>.</p>
+            </dd>
+            <dt>
+              <span class="term">
+                <code class="constant">GL_VERTEX_ATTRIB_RELATIVE_OFFSET</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                </p>
+              <p> <em class="parameter"><code>params</code></em> returns a single value that is the byte
+	          offset of the first element relative to the start of the vertex
+	          buffer binding specified attribute fetches from. The initial value
+	          is 0.</p>
             </dd>
             <dt>
               <span class="term">


### PR DESCRIPTION
As discussed in issue #54 I added the missing entries to the `glGet` and `glGetVertexAttrib` files for OpenGL 4.x. Additionally I added also missing entries for `GL_VERTEX_ATTRIB_ARRAY_LONG` and `GL_VERTEX_ATTRIB_RELATIVE_OFFSET` in the `glGetVertexAttrib` file. They are mentioned in the 4.6 specifications at page 375.

If you think the changes are okay and if you tell me in which versions those entries are also missing, I can copy them to the corresponding files. 