### PR TITLE
Add glGetQueryBufferObject* functions

### DIFF
--- a/gl4/glGetQueryObject.xml
+++ b/gl4/glGetQueryObject.xml
@@ -115,6 +115,7 @@
             <listitem>
                 <para>
                     Specifies the symbolic name of a query object parameter.
+		    Accepted values are <constant>GL_QUERY_RESULT</constant> or <constant>GL_QUERY_RESULT_AVAILABLE</constant>.
                 </para>
             </listitem>
         </varlistentry>

--- a/gl4/glGetQueryObject.xml
+++ b/gl4/glGetQueryObject.xml
@@ -19,6 +19,7 @@
     </refmeta>
     <refnamediv>
         <refname>glGetQueryObject</refname>
+        <refname>glGetQueryBufferObject</refname>
         <refpurpose>return parameters of a query object</refpurpose>
     </refnamediv>
     <refsynopsisdiv><title>C Specification</title>
@@ -54,6 +55,42 @@
                 <paramdef>GLuint64 * <parameter>params</parameter></paramdef>
             </funcprototype>
         </funcsynopsis>
+        <funcsynopsis>
+            <funcprototype>
+                <funcdef>void <function>glGetQueryBufferObjectiv</function></funcdef>
+                <paramdef>GLuint <parameter>id</parameter></paramdef>
+                <paramdef>GLuint <parameter>buffer</parameter></paramdef>
+                <paramdef>GLenum <parameter>pname</parameter></paramdef>
+                <paramdef>GLintptr <parameter>offset</parameter></paramdef>
+            </funcprototype>
+        </funcsynopsis>
+        <funcsynopsis>
+            <funcprototype>
+                <funcdef>void <function>glGetQueryBufferObjectuiv</function></funcdef>
+                <paramdef>GLuint <parameter>id</parameter></paramdef>
+                <paramdef>GLuint <parameter>buffer</parameter></paramdef>
+                <paramdef>GLenum <parameter>pname</parameter></paramdef>
+                <paramdef>GLintptr <parameter>offset</parameter></paramdef>
+            </funcprototype>
+        </funcsynopsis>
+        <funcsynopsis>
+            <funcprototype>
+                <funcdef>void <function>glGetQueryBufferObjecti64v</function></funcdef>
+                <paramdef>GLuint <parameter>id</parameter></paramdef>
+                <paramdef>GLuint <parameter>buffer</parameter></paramdef>
+                <paramdef>GLenum <parameter>pname</parameter></paramdef>
+                <paramdef>GLintptr <parameter>offset</parameter></paramdef>
+            </funcprototype>
+        </funcsynopsis>
+        <funcsynopsis>
+            <funcprototype>
+                <funcdef>void <function>glGetQueryBufferObjectui64v</function></funcdef>
+                <paramdef>GLuint <parameter>id</parameter></paramdef>
+                <paramdef>GLuint <parameter>buffer</parameter></paramdef>
+                <paramdef>GLenum <parameter>pname</parameter></paramdef>
+                <paramdef>GLintptr <parameter>offset</parameter></paramdef>
+            </funcprototype>
+        </funcsynopsis>
     </refsynopsisdiv>
     <refsect1 xml:id="parameters"><title>Parameters</title>
         <variablelist>
@@ -66,11 +103,18 @@
             </listitem>
         </varlistentry>
         <varlistentry>
+            <term><parameter>buffer</parameter></term>
+            <listitem>
+                <para>
+                    Specifies the name of a buffer object.
+                </para>
+            </listitem>
+        </varlistentry>
+        <varlistentry>
             <term><parameter>pname</parameter></term>
             <listitem>
                 <para>
                     Specifies the symbolic name of a query object parameter.
-                    Accepted values are <constant>GL_QUERY_RESULT</constant> or <constant>GL_QUERY_RESULT_AVAILABLE</constant>.
                 </para>
             </listitem>
         </varlistentry>
@@ -85,12 +129,23 @@
                 </para>
             </listitem>
         </varlistentry>
+        <varlistentry>
+            <term><parameter>offset</parameter></term>
+            <listitem>
+                <para>
+                    Specifies the byte offset into <parameter>buffer</parameter>'s data store
+                    where the queried result will be written.
+                </para>
+            </listitem>
+        </varlistentry>
         </variablelist>
     </refsect1>
     <refsect1 xml:id="description"><title>Description</title>
         <para>
-            <function>glGetQueryObject</function> returns in <parameter>params</parameter> a selected parameter of the query object
-            specified by <parameter>id</parameter>.
+            These commands return a selected parameter of the query object specified by <parameter>id</parameter>.
+            <function>glGetQueryObject</function> returns in <parameter>params</parameter> a selected parameter of the query object specified by <parameter>id</parameter>.
+            <function>glGetQueryBufferObject</function> returns in <parameter>buffer</parameter> a selected parameter of the query object specified by <parameter>id</parameter>,
+            by writing it to <parameter>buffer</parameter>'s data store at the byte offset specified by <parameter>offset</parameter>.
         </para>
         <para>
             <parameter>pname</parameter> names a specific query object parameter.  <parameter>pname</parameter> can be as follows:
@@ -100,7 +155,7 @@
                 <term><constant>GL_QUERY_RESULT</constant></term>
                 <listitem>
                     <para>
-                        <parameter>params</parameter> returns the value of the query object's passed samples counter.
+                        <parameter>params</parameter> or <parameter>buffer</parameter> returns the value of the query object's passed samples counter.
                         The initial value is 0.
                     </para>
                 </listitem>
@@ -110,8 +165,8 @@
                 <listitem>
                     <para>
                         If the result of the query is available (that is, a query of <constant>GL_QUERY_RESULT_AVAILABLE</constant> would
-                        return non-zero), then <parameter>params</parameter> returns the value of the query object's passed samples counter,
-                        otherwise, the data referred to by <parameter>params</parameter> is not modified.
+                        return non-zero), then <parameter>params</parameter> or <parameter>buffer</parameter> returns the value of the query object's passed samples counter,
+                        otherwise, the data referred to by <parameter>params</parameter> or <parameter>buffer</parameter> is not modified.
                         The initial value is 0.
                     </para>
                 </listitem>
@@ -120,7 +175,7 @@
                 <term><constant>GL_QUERY_RESULT_AVAILABLE</constant></term>
                 <listitem>
                     <para>
-                        <parameter>params</parameter> returns whether the passed samples counter is immediately available.
+                        <parameter>params</parameter> or <parameter>buffer</parameter> returns whether the passed samples counter is immediately available.
                         If a delay would occur waiting for the query result, <constant>GL_FALSE</constant> is returned.
                         Otherwise, <constant>GL_TRUE</constant> is returned, which also indicates that the results of all
                         previous queries are available as well.
@@ -132,15 +187,16 @@
     <refsect1 xml:id="notes"><title>Notes</title>
         <para>
             If an error is generated,
-            no change is made to the contents of <parameter>params</parameter>.
+            no change is made to the contents of <parameter>params</parameter> or <parameter>buffer</parameter>.
         </para>
         <para>
-            <function>glGetQueryObject</function> implicitly flushes the GL pipeline so that any incomplete rendering
+            <function>glGetQueryObject</function> and <function>glGetQueryBufferObject</function> implicitly flush the GL pipeline so that any incomplete rendering
             delimited by the occlusion query completes in finite time.
         </para>
         <para>
             If multiple queries are issued using the same query object <parameter>id</parameter> before calling
-            <function>glGetQueryObject</function>, the results of the most recent query will be returned.  In this case,
+            <function>glGetQueryObject</function> or <function>glGetQueryBufferObject</function>,
+            the results of the most recent query will be returned.  In this case,
             when issuing a new query, the results of the previous query are discarded.
         </para>
         <para>
@@ -164,13 +220,24 @@
             <constant>GL_INVALID_OPERATION</constant> is generated if <parameter>id</parameter> is not the name of a query object.
         </para>
         <para>
+            <constant>GL_INVALID_OPERATION</constant> is generated by <function>glGetQueryBufferObject</function>
+            if <parameter>buffer</parameter> is not the name of an already created buffer object.
+	</para>
+        <para>
             <constant>GL_INVALID_OPERATION</constant> is generated if <parameter>id</parameter> is the name of a currently active
             query object.
         </para>
         <para>
-            <constant>GL_INVALID_OPERATION</constant> is generated if a buffer is currently bound to the
+            <constant>GL_INVALID_OPERATION</constant> is generated by <function>glGetQueryObject</function> if a buffer is currently bound to the
             <constant>GL_QUERY_RESULT_BUFFER</constant> target and the command would cause data to be written beyond the bounds
             of that buffer's data store.
+        </para>
+        <para>
+            <constant>GL_INVALID_OPERATION</constant> is generated by <function>glGetQueryBufferObject</function>
+            if the command would cause data to be written beyond the bounds of <parameter>buffer</parameter>'s data store.
+        </para>
+        <para>
+            <constant>GL_INVALID_VALUE</constant> is generated by <function>glGetQueryBufferObject</function> if <parameter>offset</parameter> is negative.
         </para>
     </refsect1>
     <refsect1 xml:id="versions"><title>Version Support</title>
@@ -193,6 +260,22 @@
                     <row>
                         <entry><function>glGetQueryObjectuiv</function></entry>
                         <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="apiversion.xml" xpointer="xpointer(/*/*[@role='20']/*)"/>
+                    </row>
+                    <row>
+                        <entry><function>glGetQueryBufferObjecti64v</function></entry>
+                        <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="apiversion.xml" xpointer="xpointer(/*/*[@role='45']/*)"/>
+                    </row>
+                    <row>
+                        <entry><function>glGetQueryBufferObjectiv</function></entry>
+                        <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="apiversion.xml" xpointer="xpointer(/*/*[@role='45']/*)"/>
+                    </row>
+                    <row>
+                        <entry><function>glGetQueryBufferObjectui64v</function></entry>
+                        <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="apiversion.xml" xpointer="xpointer(/*/*[@role='45']/*)"/>
+                    </row>
+                    <row>
+                        <entry><function>glGetQueryBufferObjectuiv</function></entry>
+                        <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="apiversion.xml" xpointer="xpointer(/*/*[@role='45']/*)"/>
                     </row>
                 </tbody>
             </tgroup>

--- a/gl4/html/glGetQueryObject.xhtml
+++ b/gl4/html/glGetQueryObject.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title>glGetQueryObject - OpenGL 4 Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="opengl-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.2"/>
     <script type="text/x-mathjax-config">
             MathJax.Hub.Config({
                 MathML: {
@@ -22,7 +22,7 @@
       <div class="titlepage"/>
       <div class="refnamediv">
         <h2>Name</h2>
-        <p>glGetQueryObject — return parameters of a query object</p>
+        <p>glGetQueryObject, glGetQueryBufferObject — return parameters of a query object</p>
       </div>
       <div class="refsynopsisdiv">
         <h2>C Specification</h2>
@@ -102,6 +102,98 @@
           </table>
           <div class="funcprototype-spacer"> </div>
         </div>
+        <div class="funcsynopsis">
+          <table style="border: 0; cellspacing: 0; cellpadding: 0;" class="funcprototype-table">
+            <tr>
+              <td>
+                <code class="funcdef">void <strong class="fsfunc">glGetQueryBufferObjectiv</strong>(</code>
+              </td>
+              <td>GLuint <var class="pdparam">id</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>GLuint <var class="pdparam">buffer</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>GLenum <var class="pdparam">pname</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>GLintptr <var class="pdparam">offset</var><code>)</code>;</td>
+            </tr>
+          </table>
+          <div class="funcprototype-spacer"> </div>
+        </div>
+        <div class="funcsynopsis">
+          <table style="border: 0; cellspacing: 0; cellpadding: 0;" class="funcprototype-table">
+            <tr>
+              <td>
+                <code class="funcdef">void <strong class="fsfunc">glGetQueryBufferObjectuiv</strong>(</code>
+              </td>
+              <td>GLuint <var class="pdparam">id</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>GLuint <var class="pdparam">buffer</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>GLenum <var class="pdparam">pname</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>GLintptr <var class="pdparam">offset</var><code>)</code>;</td>
+            </tr>
+          </table>
+          <div class="funcprototype-spacer"> </div>
+        </div>
+        <div class="funcsynopsis">
+          <table style="border: 0; cellspacing: 0; cellpadding: 0;" class="funcprototype-table">
+            <tr>
+              <td>
+                <code class="funcdef">void <strong class="fsfunc">glGetQueryBufferObjecti64v</strong>(</code>
+              </td>
+              <td>GLuint <var class="pdparam">id</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>GLuint <var class="pdparam">buffer</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>GLenum <var class="pdparam">pname</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>GLintptr <var class="pdparam">offset</var><code>)</code>;</td>
+            </tr>
+          </table>
+          <div class="funcprototype-spacer"> </div>
+        </div>
+        <div class="funcsynopsis">
+          <table style="border: 0; cellspacing: 0; cellpadding: 0;" class="funcprototype-table">
+            <tr>
+              <td>
+                <code class="funcdef">void <strong class="fsfunc">glGetQueryBufferObjectui64v</strong>(</code>
+              </td>
+              <td>GLuint <var class="pdparam">id</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>GLuint <var class="pdparam">buffer</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>GLenum <var class="pdparam">pname</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>GLintptr <var class="pdparam">offset</var><code>)</code>;</td>
+            </tr>
+          </table>
+          <div class="funcprototype-spacer"> </div>
+        </div>
       </div>
       <div class="refsect1" id="parameters">
         <h2>Parameters</h2>
@@ -122,6 +214,18 @@
             <dt>
               <span class="term">
                 <em class="parameter">
+                  <code>buffer</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies the name of a buffer object.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
                   <code>pname</code>
                 </em>
               </span>
@@ -129,7 +233,6 @@
             <dd>
               <p>
                     Specifies the symbolic name of a query object parameter.
-                    Accepted values are <code class="constant">GL_QUERY_RESULT</code> or <code class="constant">GL_QUERY_RESULT_AVAILABLE</code>.
                 </p>
             </dd>
             <dt>
@@ -147,14 +250,29 @@
                     treated as an address in client memory of a variable to receive the resulting data.
                 </p>
             </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>offset</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies the byte offset into <em class="parameter"><code>buffer</code></em>'s data store
+                    where the queried result will be written.
+                </p>
+            </dd>
           </dl>
         </div>
       </div>
       <div class="refsect1" id="description">
         <h2>Description</h2>
         <p>
-            <code class="function">glGetQueryObject</code> returns in <em class="parameter"><code>params</code></em> a selected parameter of the query object
-            specified by <em class="parameter"><code>id</code></em>.
+            These commands return a selected parameter of the query object specified by <em class="parameter"><code>id</code></em>.
+            <code class="function">glGetQueryObject</code> returns in <em class="parameter"><code>params</code></em> a selected parameter of the query object specified by <em class="parameter"><code>id</code></em>.
+            <code class="function">glGetQueryBufferObject</code> returns in <em class="parameter"><code>buffer</code></em> a selected parameter of the query object specified by <em class="parameter"><code>id</code></em>,
+            by writing it to <em class="parameter"><code>buffer</code></em>'s data store at the byte offset specified by <em class="parameter"><code>offset</code></em>.
         </p>
         <p>
             <em class="parameter"><code>pname</code></em> names a specific query object parameter.  <em class="parameter"><code>pname</code></em> can be as follows:
@@ -168,7 +286,7 @@
             </dt>
             <dd>
               <p>
-                        <em class="parameter"><code>params</code></em> returns the value of the query object's passed samples counter.
+                        <em class="parameter"><code>params</code></em> or <em class="parameter"><code>buffer</code></em> returns the value of the query object's passed samples counter.
                         The initial value is 0.
                     </p>
             </dd>
@@ -180,8 +298,8 @@
             <dd>
               <p>
                         If the result of the query is available (that is, a query of <code class="constant">GL_QUERY_RESULT_AVAILABLE</code> would
-                        return non-zero), then <em class="parameter"><code>params</code></em> returns the value of the query object's passed samples counter,
-                        otherwise, the data referred to by <em class="parameter"><code>params</code></em> is not modified.
+                        return non-zero), then <em class="parameter"><code>params</code></em> or <em class="parameter"><code>buffer</code></em> returns the value of the query object's passed samples counter,
+                        otherwise, the data referred to by <em class="parameter"><code>params</code></em> or <em class="parameter"><code>buffer</code></em> is not modified.
                         The initial value is 0.
                     </p>
             </dd>
@@ -192,7 +310,7 @@
             </dt>
             <dd>
               <p>
-                        <em class="parameter"><code>params</code></em> returns whether the passed samples counter is immediately available.
+                        <em class="parameter"><code>params</code></em> or <em class="parameter"><code>buffer</code></em> returns whether the passed samples counter is immediately available.
                         If a delay would occur waiting for the query result, <code class="constant">GL_FALSE</code> is returned.
                         Otherwise, <code class="constant">GL_TRUE</code> is returned, which also indicates that the results of all
                         previous queries are available as well.
@@ -205,15 +323,16 @@
         <h2>Notes</h2>
         <p>
             If an error is generated,
-            no change is made to the contents of <em class="parameter"><code>params</code></em>.
+            no change is made to the contents of <em class="parameter"><code>params</code></em> or <em class="parameter"><code>buffer</code></em>.
         </p>
         <p>
-            <code class="function">glGetQueryObject</code> implicitly flushes the GL pipeline so that any incomplete rendering
+            <code class="function">glGetQueryObject</code> and <code class="function">glGetQueryBufferObject</code> implicitly flush the GL pipeline so that any incomplete rendering
             delimited by the occlusion query completes in finite time.
         </p>
         <p>
             If multiple queries are issued using the same query object <em class="parameter"><code>id</code></em> before calling
-            <code class="function">glGetQueryObject</code>, the results of the most recent query will be returned.  In this case,
+            <code class="function">glGetQueryObject</code> or <code class="function">glGetQueryBufferObject</code>,
+            the results of the most recent query will be returned.  In this case,
             when issuing a new query, the results of the previous query are discarded.
         </p>
         <p>
@@ -238,13 +357,24 @@
             <code class="constant">GL_INVALID_OPERATION</code> is generated if <em class="parameter"><code>id</code></em> is not the name of a query object.
         </p>
         <p>
+            <code class="constant">GL_INVALID_OPERATION</code> is generated by <code class="function">glGetQueryBufferObject</code>
+            if <em class="parameter"><code>buffer</code></em> is not the name of an already created buffer object.
+	</p>
+        <p>
             <code class="constant">GL_INVALID_OPERATION</code> is generated if <em class="parameter"><code>id</code></em> is the name of a currently active
             query object.
         </p>
         <p>
-            <code class="constant">GL_INVALID_OPERATION</code> is generated if a buffer is currently bound to the
+            <code class="constant">GL_INVALID_OPERATION</code> is generated by <code class="function">glGetQueryObject</code> if a buffer is currently bound to the
             <code class="constant">GL_QUERY_RESULT_BUFFER</code> target and the command would cause data to be written beyond the bounds
             of that buffer's data store.
+        </p>
+        <p>
+            <code class="constant">GL_INVALID_OPERATION</code> is generated by <code class="function">glGetQueryBufferObject</code>
+            if the command would cause data to be written beyond the bounds of <em class="parameter"><code>buffer</code></em>'s data store.
+        </p>
+        <p>
+            <code class="constant">GL_INVALID_VALUE</code> is generated by <code class="function">glGetQueryBufferObject</code> if <em class="parameter"><code>offset</code></em> is negative.
         </p>
       </div>
       <div class="refsect1" id="versions">
@@ -370,20 +500,88 @@
                 <td style="text-align: center; border-bottom: 2px solid ; ">✔</td>
               </tr>
               <tr>
-                <td style="text-align: left; border-right: 2px solid ; ">
+                <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">
                   <code class="function">glGetQueryObjectuiv</code>
                 </td>
-                <td style="text-align: center; border-right: 2px solid ; ">✔</td>
-                <td style="text-align: center; border-right: 2px solid ; ">✔</td>
-                <td style="text-align: center; border-right: 2px solid ; ">✔</td>
-                <td style="text-align: center; border-right: 2px solid ; ">✔</td>
-                <td style="text-align: center; border-right: 2px solid ; ">✔</td>
-                <td style="text-align: center; border-right: 2px solid ; ">✔</td>
-                <td style="text-align: center; border-right: 2px solid ; ">✔</td>
-                <td style="text-align: center; border-right: 2px solid ; ">✔</td>
-                <td style="text-align: center; border-right: 2px solid ; ">✔</td>
-                <td style="text-align: center; border-right: 2px solid ; ">✔</td>
-                <td style="text-align: center; border-right: 2px solid ; ">✔</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">✔</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">✔</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">✔</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">✔</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">✔</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">✔</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">✔</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">✔</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">✔</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">✔</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">✔</td>
+                <td style="text-align: center; border-bottom: 2px solid ; ">✔</td>
+              </tr>
+              <tr>
+                <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">
+                  <code class="function">glGetQueryBufferObjecti64v</code>
+                </td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-bottom: 2px solid ; ">✔</td>
+              </tr>
+              <tr>
+                <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">
+                  <code class="function">glGetQueryBufferObjectiv</code>
+                </td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-bottom: 2px solid ; ">✔</td>
+              </tr>
+              <tr>
+                <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">
+                  <code class="function">glGetQueryBufferObjectui64v</code>
+                </td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
+                <td style="text-align: center; border-bottom: 2px solid ; ">✔</td>
+              </tr>
+              <tr>
+                <td style="text-align: left; border-right: 2px solid ; ">
+                  <code class="function">glGetQueryBufferObjectuiv</code>
+                </td>
+                <td style="text-align: center; border-right: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; ">-</td>
+                <td style="text-align: center; border-right: 2px solid ; ">-</td>
                 <td style="text-align: center; ">✔</td>
               </tr>
             </tbody>

--- a/gl4/html/glGetQueryObject.xhtml
+++ b/gl4/html/glGetQueryObject.xhtml
@@ -233,6 +233,7 @@
             <dd>
               <p>
                     Specifies the symbolic name of a query object parameter.
+		    Accepted values are <code class="constant">GL_QUERY_RESULT</code> or <code class="constant">GL_QUERY_RESULT_AVAILABLE</code>.
                 </p>
             </dd>
             <dt>

--- a/gl4/html/index.php
+++ b/gl4/html/index.php
@@ -311,6 +311,10 @@
                 <li><a href="glGetProgramResourceName.xhtml" target="pagedisplay">glGetProgramResourceName</a></li>
                 <li><a href="glGetProgramStage.xhtml" target="pagedisplay">glGetProgramStage</a></li>
                 <li><a href="glGetProgramStage.xhtml" target="pagedisplay">glGetProgramStageiv</a></li>
+                <li><a href="glGetQueryObject.xhtml" target="pagedisplay">glGetQueryBufferObjecti64v</a></li>
+                <li><a href="glGetQueryObject.xhtml" target="pagedisplay">glGetQueryBufferObjectiv</a></li>
+                <li><a href="glGetQueryObject.xhtml" target="pagedisplay">glGetQueryBufferObjectui64v</a></li>
+                <li><a href="glGetQueryObject.xhtml" target="pagedisplay">glGetQueryBufferObjectuiv</a></li>
                 <li><a href="glGetQueryIndexed.xhtml" target="pagedisplay">glGetQueryIndexed</a></li>
                 <li><a href="glGetQueryIndexed.xhtml" target="pagedisplay">glGetQueryIndexediv</a></li>
                 <li><a href="glGetQueryiv.xhtml" target="pagedisplay">glGetQueryiv</a></li>

--- a/gl4/html/indexflat.php
+++ b/gl4/html/indexflat.php
@@ -395,6 +395,10 @@
                 <li><a href="glGetProgramResourceName.xhtml" target="pagedisplay">glGetProgramResourceName</a></li>
                 <li><a href="glGetProgramStage.xhtml" target="pagedisplay">glGetProgramStage</a></li>
                 <li><a href="glGetProgramStage.xhtml" target="pagedisplay">glGetProgramStageiv</a></li>
+                <li><a href="glGetQueryObject.xhtml" target="pagedisplay">glGetQueryBufferObjecti64v</a></li>
+                <li><a href="glGetQueryObject.xhtml" target="pagedisplay">glGetQueryBufferObjectiv</a></li>
+                <li><a href="glGetQueryObject.xhtml" target="pagedisplay">glGetQueryBufferObjectui64v</a></li>
+                <li><a href="glGetQueryObject.xhtml" target="pagedisplay">glGetQueryBufferObjectuiv</a></li>
                 <li><a href="glGetQueryIndexed.xhtml" target="pagedisplay">glGetQueryIndexed</a></li>
                 <li><a href="glGetQueryIndexed.xhtml" target="pagedisplay">glGetQueryIndexediv</a></li>
                 <li><a href="glGetQueryiv.xhtml" target="pagedisplay">glGetQueryiv</a></li>


### PR DESCRIPTION
Fixes #10. All info added based on the [ARB_direct_state_access](https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_direct_state_access.txt) extension that was made core in GL 4.5. There's virtually no other documentation of the functions.