### PR TITLE
Add some missing errors for ES3 glDrawElementsIndirect.

### DIFF
--- a/es3.1/glDrawElementsIndirect.xml
+++ b/es3.1/glDrawElementsIndirect.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="glDrawElementsIndirect">
     <info>
         <copyright>
-            <year>2010-2014</year>
+            <year>2010-2019</year>
             <holder>Khronos Group.</holder>
         </copyright>
     </info>
@@ -28,7 +28,6 @@
             </funcprototype>
         </funcsynopsis>
     </refsynopsisdiv>
-    <!-- eqn: ignoring delim $$ -->
     <refsect1 xml:id="parameters"><title>Parameters</title>
         <variablelist>
         <varlistentry>
@@ -76,8 +75,8 @@
             transferred by the corresponding draw call will be taken from element <parameter>indices</parameter>[i] + <parameter>baseVertex</parameter>
             of each enabled array. If the resulting value is larger than the maximum value representable by <parameter>type</parameter>,
             it is as if the calculation were upconverted to 32-bit unsigned integers (with wrapping on overflow conditions).
-            The operation is undefined if the sum would be negative.It also supports the addition of 
-			a value baseVertex to each index.
+            The operation is undefined if the sum would be negative.It also supports the addition of
+            a value baseVertex to each index.
         </para>
         <para>
             The parameters addressed by <parameter>indirect</parameter> are packed into a structure
@@ -129,17 +128,29 @@
         <para>
             <function>glDrawElementsInstancedBaseVertex</function> isn't actually present in OpenGL ES, but is used to describe this functionality.
         </para>
-    </refsect1>    <refsect1 xml:id="errors"><title>Errors</title>
+    </refsect1>
+    <refsect1 xml:id="errors"><title>Errors</title>
         <para>
-            <constant>GL_INVALID_ENUM</constant> is generated if <parameter>mode</parameter> is not an accepted value.
+            <constant>GL_INVALID_ENUM</constant> is generated if
+            <parameter>mode</parameter> is not an accepted value.
         </para>
         <para>
-            <constant>GL_INVALID_OPERATION</constant> is generated if no buffer is bound to the <constant>GL_ELEMENT_ARRAY_BUFFER</constant>
-            binding, or if such a buffer's data store is currently mapped.
+            <constant>GL_INVALID_OPERATION</constant> is generated if zero
+            is bound to the <constant>GL_VERTEX_ARRAY_BINDING</constant>,
+            <constant>GL_DRAW_INDIRECT_BUFFER</constant>, or
+            <constant>GL_ELEMENT_ARRAY_BUFFER</constant> binding, or to any
+            enabled vertex array.
+                <!-- old text said that buffers could not be mapped, but that's not in 3.2 spec -->
         </para>
         <para>
-            <constant>GL_INVALID_OPERATION</constant> is generated if a non-zero buffer object name is bound to an
-            enabled array or to the <constant>GL_DRAW_INDIRECT_BUFFER</constant> binding and the buffer object's data store is currently mapped.
+            <constant>GL_INVALID_OPERATION</constant> is generated if the
+            command would source data beyond the end of any bound buffer
+            object.
+        </para>
+        <para>
+            <constant>GL_INVALID_VALUE</constant> is generated if
+            <parameter>indirect</parameter> is not a multiple of the size,
+            in basic machine units, of <code>GLuint</code>.
         </para>
     </refsect1>
     <refsect1 xml:id="versions">
@@ -167,8 +178,8 @@
     </refsect1>
     <refsect1 xml:id="Copyright"><title>Copyright</title>
         <para>
-            Copyright <trademark class="copyright"/> 2010-2014 Khronos Group. 
-            This material may be distributed subject to the terms and conditions set forth in 
+            Copyright <trademark class="copyright"/> 2010-2019 Khronos Group.
+            This material may be distributed subject to the terms and conditions set forth in
             the Open Publication License, v 1.0, 8 June 1999.
             <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://opencontent.org/openpub/">http://opencontent.org/openpub/</link>.
         </para>

--- a/es3.1/html/glDrawElementsIndirect.xhtml
+++ b/es3.1/html/glDrawElementsIndirect.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title>glDrawElementsIndirect - OpenGL ES 3.1 Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="opengl-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
     <script type="text/x-mathjax-config">
             MathJax.Hub.Config({
                 MathML: {
@@ -109,8 +109,8 @@
             transferred by the corresponding draw call will be taken from element <em class="parameter"><code>indices</code></em>[i] + <em class="parameter"><code>baseVertex</code></em>
             of each enabled array. If the resulting value is larger than the maximum value representable by <em class="parameter"><code>type</code></em>,
             it is as if the calculation were upconverted to 32-bit unsigned integers (with wrapping on overflow conditions).
-            The operation is undefined if the sum would be negative.It also supports the addition of 
-			a value baseVertex to each index.
+            The operation is undefined if the sum would be negative.It also supports the addition of
+            a value baseVertex to each index.
         </p>
         <p>
             The parameters addressed by <em class="parameter"><code>indirect</code></em> are packed into a structure
@@ -169,15 +169,26 @@
       <div class="refsect1" id="errors">
         <h2>Errors</h2>
         <p>
-            <code class="constant">GL_INVALID_ENUM</code> is generated if <em class="parameter"><code>mode</code></em> is not an accepted value.
+            <code class="constant">GL_INVALID_ENUM</code> is generated if
+            <em class="parameter"><code>mode</code></em> is not an accepted value.
         </p>
         <p>
-            <code class="constant">GL_INVALID_OPERATION</code> is generated if no buffer is bound to the <code class="constant">GL_ELEMENT_ARRAY_BUFFER</code>
-            binding, or if such a buffer's data store is currently mapped.
+            <code class="constant">GL_INVALID_OPERATION</code> is generated if zero
+            is bound to the <code class="constant">GL_VERTEX_ARRAY_BINDING</code>,
+            <code class="constant">GL_DRAW_INDIRECT_BUFFER</code>, or
+            <code class="constant">GL_ELEMENT_ARRAY_BUFFER</code> binding, or to any
+            enabled vertex array.
+                
         </p>
         <p>
-            <code class="constant">GL_INVALID_OPERATION</code> is generated if a non-zero buffer object name is bound to an
-            enabled array or to the <code class="constant">GL_DRAW_INDIRECT_BUFFER</code> binding and the buffer object's data store is currently mapped.
+            <code class="constant">GL_INVALID_OPERATION</code> is generated if the
+            command would source data beyond the end of any bound buffer
+            object.
+        </p>
+        <p>
+            <code class="constant">GL_INVALID_VALUE</code> is generated if
+            <em class="parameter"><code>indirect</code></em> is not a multiple of the size,
+            in basic machine units, of <code class="code">GLuint</code>.
         </p>
       </div>
       <div class="refsect1" id="versions">
@@ -240,8 +251,8 @@
       <div class="refsect1" id="Copyright">
         <h2>Copyright</h2>
         <p>
-            Copyright <span class="trademark"/>© 2010-2014 Khronos Group. 
-            This material may be distributed subject to the terms and conditions set forth in 
+            Copyright <span class="trademark"/>© 2010-2019 Khronos Group.
+            This material may be distributed subject to the terms and conditions set forth in
             the Open Publication License, v 1.0, 8 June 1999.
             <a class="link" href="http://opencontent.org/openpub/" target="_top">http://opencontent.org/openpub/</a>.
         </p>

--- a/es3/glDrawElementsIndirect.xml
+++ b/es3/glDrawElementsIndirect.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="glDrawElementsIndirect">
     <info>
         <copyright>
-            <year>2010-2015</year>
+            <year>2010-2019</year>
             <holder>Khronos Group.</holder>
         </copyright>
     </info>
@@ -28,7 +28,6 @@
             </funcprototype>
         </funcsynopsis>
     </refsynopsisdiv>
-    <!-- eqn: ignoring delim $$ -->
     <refsect1 xml:id="parameters"><title>Parameters</title>
         <variablelist>
         <varlistentry>
@@ -47,7 +46,7 @@
                     <constant>GL_TRIANGLE_FAN</constant>,
                     <constant>GL_TRIANGLES</constant>,
                     <constant>GL_TRIANGLE_STRIP_ADJACENCY</constant>,
-                    <constant>GL_TRIANGLES_ADJACENCY</constant> and 
+                    <constant>GL_TRIANGLES_ADJACENCY</constant>, and
                     <constant>GL_PATCHES</constant>
                     are accepted.
                 </para>
@@ -81,8 +80,8 @@
             transferred by the corresponding draw call will be taken from element <parameter>indices</parameter>[i] + <parameter>baseVertex</parameter>
             of each enabled array. If the resulting value is larger than the maximum value representable by <parameter>type</parameter>,
             it is as if the calculation were upconverted to 32-bit unsigned integers (with wrapping on overflow conditions).
-            The operation is undefined if the sum would be negative.It also supports the addition of 
-			a value baseVertex to each index.
+            The operation is undefined if the sum would be negative.It also supports the addition of
+            a value baseVertex to each index.
         </para>
         <para>
             The parameters addressed by <parameter>indirect</parameter> are packed into a structure
@@ -142,21 +141,35 @@
             <constant>GL_PATCHES</constant>
             are available only if the GL ES version is 3.2 or greater.
         </para>
-    </refsect1>    <refsect1 xml:id="errors"><title>Errors</title>
+    </refsect1>
+    <refsect1 xml:id="errors"><title>Errors</title>
         <para>
-            <constant>GL_INVALID_ENUM</constant> is generated if <parameter>mode</parameter> is not an accepted value.
+            <constant>GL_INVALID_ENUM</constant> is generated if
+            <parameter>mode</parameter> is not an accepted value.
         </para>
         <para>
-            <constant>GL_INVALID_OPERATION</constant> is generated if no buffer is bound to the <constant>GL_ELEMENT_ARRAY_BUFFER</constant>
-            binding, or if such a buffer's data store is currently mapped.
+            <constant>GL_INVALID_OPERATION</constant> is generated if zero
+            is bound to the <constant>GL_VERTEX_ARRAY_BINDING</constant>,
+            <constant>GL_DRAW_INDIRECT_BUFFER</constant>, or
+            <constant>GL_ELEMENT_ARRAY_BUFFER</constant> binding, or to any
+            enabled vertex array.
+                <!-- old text said that buffers could not be mapped, but that's not in 3.2 spec -->
         </para>
         <para>
-            <constant>GL_INVALID_OPERATION</constant> is generated if a non-zero buffer object name is bound to an
-            enabled array or to the <constant>GL_DRAW_INDIRECT_BUFFER</constant> binding and the buffer object's data store is currently mapped.
+            <constant>GL_INVALID_OPERATION</constant> is generated if the
+            command would source data beyond the end of any bound buffer
+            object.
         </para>
         <para>
-            <constant>GL_INVALID_OPERATION</constant> is generated if a geometry shader is active and <parameter>mode</parameter>
-            is incompatible with the input primitive type of the geometry shader in the currently installed program object.
+            <constant>GL_INVALID_VALUE</constant> is generated if
+            <parameter>indirect</parameter> is not a multiple of the size,
+            in basic machine units, of <code>GLuint</code>.
+        </para>
+        <para>
+            <constant>GL_INVALID_OPERATION</constant> is generated if a
+            geometry shader is active and <parameter>mode</parameter> is
+            incompatible with the input primitive type of the geometry
+            shader in the currently installed program object.
         </para>
     </refsect1>
     <refsect1 xml:id="versions">
@@ -184,8 +197,8 @@
     </refsect1>
     <refsect1 xml:id="Copyright"><title>Copyright</title>
         <para>
-            Copyright <trademark class="copyright"/> 2010-2015 Khronos Group. 
-            This material may be distributed subject to the terms and conditions set forth in 
+            Copyright <trademark class="copyright"/> 2010-2019 Khronos Group.
+            This material may be distributed subject to the terms and conditions set forth in
             the Open Publication License, v 1.0, 8 June 1999.
             <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://opencontent.org/openpub/">http://opencontent.org/openpub/</link>.
         </para>

--- a/es3/html/glDrawElementsIndirect.xhtml
+++ b/es3/html/glDrawElementsIndirect.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title>glDrawElementsIndirect - OpenGL ES 3.2 Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="opengl-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
     <script type="text/x-mathjax-config">
             MathJax.Hub.Config({
                 MathML: {
@@ -71,7 +71,7 @@
                     <code class="constant">GL_TRIANGLE_FAN</code>,
                     <code class="constant">GL_TRIANGLES</code>,
                     <code class="constant">GL_TRIANGLE_STRIP_ADJACENCY</code>,
-                    <code class="constant">GL_TRIANGLES_ADJACENCY</code> and 
+                    <code class="constant">GL_TRIANGLES_ADJACENCY</code>, and
                     <code class="constant">GL_PATCHES</code>
                     are accepted.
                 </p>
@@ -114,8 +114,8 @@
             transferred by the corresponding draw call will be taken from element <em class="parameter"><code>indices</code></em>[i] + <em class="parameter"><code>baseVertex</code></em>
             of each enabled array. If the resulting value is larger than the maximum value representable by <em class="parameter"><code>type</code></em>,
             it is as if the calculation were upconverted to 32-bit unsigned integers (with wrapping on overflow conditions).
-            The operation is undefined if the sum would be negative.It also supports the addition of 
-			a value baseVertex to each index.
+            The operation is undefined if the sum would be negative.It also supports the addition of
+            a value baseVertex to each index.
         </p>
         <p>
             The parameters addressed by <em class="parameter"><code>indirect</code></em> are packed into a structure
@@ -182,19 +182,32 @@
       <div class="refsect1" id="errors">
         <h2>Errors</h2>
         <p>
-            <code class="constant">GL_INVALID_ENUM</code> is generated if <em class="parameter"><code>mode</code></em> is not an accepted value.
+            <code class="constant">GL_INVALID_ENUM</code> is generated if
+            <em class="parameter"><code>mode</code></em> is not an accepted value.
         </p>
         <p>
-            <code class="constant">GL_INVALID_OPERATION</code> is generated if no buffer is bound to the <code class="constant">GL_ELEMENT_ARRAY_BUFFER</code>
-            binding, or if such a buffer's data store is currently mapped.
+            <code class="constant">GL_INVALID_OPERATION</code> is generated if zero
+            is bound to the <code class="constant">GL_VERTEX_ARRAY_BINDING</code>,
+            <code class="constant">GL_DRAW_INDIRECT_BUFFER</code>, or
+            <code class="constant">GL_ELEMENT_ARRAY_BUFFER</code> binding, or to any
+            enabled vertex array.
+                
         </p>
         <p>
-            <code class="constant">GL_INVALID_OPERATION</code> is generated if a non-zero buffer object name is bound to an
-            enabled array or to the <code class="constant">GL_DRAW_INDIRECT_BUFFER</code> binding and the buffer object's data store is currently mapped.
+            <code class="constant">GL_INVALID_OPERATION</code> is generated if the
+            command would source data beyond the end of any bound buffer
+            object.
         </p>
         <p>
-            <code class="constant">GL_INVALID_OPERATION</code> is generated if a geometry shader is active and <em class="parameter"><code>mode</code></em>
-            is incompatible with the input primitive type of the geometry shader in the currently installed program object.
+            <code class="constant">GL_INVALID_VALUE</code> is generated if
+            <em class="parameter"><code>indirect</code></em> is not a multiple of the size,
+            in basic machine units, of <code class="code">GLuint</code>.
+        </p>
+        <p>
+            <code class="constant">GL_INVALID_OPERATION</code> is generated if a
+            geometry shader is active and <em class="parameter"><code>mode</code></em> is
+            incompatible with the input primitive type of the geometry
+            shader in the currently installed program object.
         </p>
       </div>
       <div class="refsect1" id="versions">
@@ -262,8 +275,8 @@
       <div class="refsect1" id="Copyright">
         <h2>Copyright</h2>
         <p>
-            Copyright <span class="trademark"/>© 2010-2015 Khronos Group. 
-            This material may be distributed subject to the terms and conditions set forth in 
+            Copyright <span class="trademark"/>© 2010-2019 Khronos Group.
+            This material may be distributed subject to the terms and conditions set forth in
             the Open Publication License, v 1.0, 8 June 1999.
             <a class="link" href="http://opencontent.org/openpub/" target="_top">http://opencontent.org/openpub/</a>.
         </p>

--- a/es3/html/indexflat.php
+++ b/es3/html/indexflat.php
@@ -422,8 +422,8 @@
                 <li><a href="glMapBufferRange.xhtml" target="pagedisplay">glMapBufferRange</a></li>
                 <li><a href="matrixCompMult.xhtml" target="pagedisplay">matrixCompMult</a></li>
                 <li><a href="max.xhtml" target="pagedisplay">max</a></li>
-                <li><a href="glMemoryBarrier.xhtml" target="pagedisplay">glMemoryBarrier</a></li>
                 <li><a href="memoryBarrier.xhtml" target="pagedisplay">memoryBarrier</a></li>
+                <li><a href="glMemoryBarrier.xhtml" target="pagedisplay">glMemoryBarrier</a></li>
                 <li><a href="memoryBarrierAtomicCounter.xhtml" target="pagedisplay">memoryBarrierAtomicCounter</a></li>
                 <li><a href="memoryBarrierBuffer.xhtml" target="pagedisplay">memoryBarrierBuffer</a></li>
                 <li><a href="glMemoryBarrier.xhtml" target="pagedisplay">glMemoryBarrierByRegion</a></li>

--- a/gl4/glDrawElementsIndirect.xml
+++ b/gl4/glDrawElementsIndirect.xml
@@ -17,7 +17,8 @@
         <refname>glDrawElementsIndirect</refname>
         <refpurpose>render indexed primitives from array data, taking parameters from memory</refpurpose>
     </refnamediv>
-    <refsynopsisdiv><title>C Specification</title>
+    <refsynopsisdiv>
+        <title>C Specification</title>
         <funcsynopsis>
             <funcprototype>
                 <funcdef>void <function>glDrawElementsIndirect</function></funcdef>
@@ -80,6 +81,7 @@
         <para>
             The parameters addressed by <parameter>indirect</parameter> are packed into a structure
             that takes the form (in C):
+        </para>
             <programlisting>    typedef  struct {
         uint  count;
         uint  primCount;
@@ -87,7 +89,6 @@
         uint  baseVertex;
         uint  baseInstance;
     } DrawElementsIndirectCommand;</programlisting>
-        </para>
         <para>
             <function>glDrawElementsIndirect</function> is equivalent to:
         </para>
@@ -136,7 +137,8 @@
             <constant>GL_INVALID_ENUM</constant> is generated if <parameter>mode</parameter> is not an accepted value.
         </para>
         <para>
-            <constant>GL_INVALID_OPERATION</constant> is generated if no buffer is bound to the <constant>GL_ELEMENT_ARRAY_BUFFER</constant>
+            <constant>GL_INVALID_OPERATION</constant> is generated if zero
+            is bound to the <constant>GL_ELEMENT_ARRAY_BUFFER</constant>
             binding, or if such a buffer's data store is currently mapped.
         </para>
         <para>

--- a/gl4/html/glDrawElementsIndirect.xhtml
+++ b/gl4/html/glDrawElementsIndirect.xhtml
@@ -115,7 +115,7 @@
         <p>
             The parameters addressed by <em class="parameter"><code>indirect</code></em> are packed into a structure
             that takes the form (in C):
-            </p>
+        </p>
         <pre class="programlisting">    typedef  struct {
         uint  count;
         uint  primCount;
@@ -123,8 +123,6 @@
         uint  baseVertex;
         uint  baseInstance;
     } DrawElementsIndirectCommand;</pre>
-        <p>
-        </p>
         <p>
             <code class="function">glDrawElementsIndirect</code> is equivalent to:
         </p>
@@ -177,7 +175,8 @@
             <code class="constant">GL_INVALID_ENUM</code> is generated if <em class="parameter"><code>mode</code></em> is not an accepted value.
         </p>
         <p>
-            <code class="constant">GL_INVALID_OPERATION</code> is generated if no buffer is bound to the <code class="constant">GL_ELEMENT_ARRAY_BUFFER</code>
+            <code class="constant">GL_INVALID_OPERATION</code> is generated if zero
+            is bound to the <code class="constant">GL_ELEMENT_ARRAY_BUFFER</code>
             binding, or if such a buffer's data store is currently mapped.
         </p>
         <p>

--- a/gl4/html/indexflat.php
+++ b/gl4/html/indexflat.php
@@ -582,8 +582,8 @@
                 <li><a href="glMapBufferRange.xhtml" target="pagedisplay">glMapNamedBufferRange</a></li>
                 <li><a href="matrixCompMult.xhtml" target="pagedisplay">matrixCompMult</a></li>
                 <li><a href="max.xhtml" target="pagedisplay">max</a></li>
-                <li><a href="memoryBarrier.xhtml" target="pagedisplay">memoryBarrier</a></li>
                 <li><a href="glMemoryBarrier.xhtml" target="pagedisplay">glMemoryBarrier</a></li>
+                <li><a href="memoryBarrier.xhtml" target="pagedisplay">memoryBarrier</a></li>
                 <li><a href="memoryBarrierAtomicCounter.xhtml" target="pagedisplay">memoryBarrierAtomicCounter</a></li>
                 <li><a href="memoryBarrierBuffer.xhtml" target="pagedisplay">memoryBarrierBuffer</a></li>
                 <li><a href="glMemoryBarrier.xhtml" target="pagedisplay">glMemoryBarrierByRegion</a></li>


### PR DESCRIPTION
Fixes gitlab #119.

N.b. there are dozens of validation-level errors applying to all draw calls, which aren't captured in the reference pages and may never be. This just fixes the issue that ES can't source indirect parameters from CPU memory, and requires buffers be bound for everything it is sourcing.