### PR TITLE
Change 'vec4 P' to 'vec3 P' for textureLod / textureLodOffset with a sampler2DShadow, matching GLSL spec.

### DIFF
--- a/gl4/html/textureLod.xhtml
+++ b/gl4/html/textureLod.xhtml
@@ -121,7 +121,7 @@
             </tr>
             <tr>
               <td> </td>
-              <td>vec4 <var class="pdparam">P</var>, </td>
+              <td>vec3 <var class="pdparam">P</var>, </td>
             </tr>
             <tr>
               <td> </td>

--- a/gl4/html/textureLodOffset.xhtml
+++ b/gl4/html/textureLodOffset.xhtml
@@ -120,7 +120,7 @@
             </tr>
             <tr>
               <td> </td>
-              <td>vec4 <var class="pdparam">P</var>, </td>
+              <td>vec3 <var class="pdparam">P</var>, </td>
             </tr>
             <tr>
               <td> </td>

--- a/gl4/textureLod.xml
+++ b/gl4/textureLod.xml
@@ -52,7 +52,7 @@
             <funcprototype>
                 <funcdef>float <function>textureLod</function></funcdef>
                 <paramdef>sampler2DShadow <parameter>sampler</parameter></paramdef>
-                <paramdef>vec4 <parameter>P</parameter></paramdef>
+                <paramdef>vec3 <parameter>P</parameter></paramdef>
                 <paramdef>float <parameter>lod</parameter></paramdef>
             </funcprototype>
             <funcprototype>

--- a/gl4/textureLodOffset.xml
+++ b/gl4/textureLodOffset.xml
@@ -50,7 +50,7 @@
             <funcprototype>
                 <funcdef>float <function>textureLodOffset</function></funcdef>
                 <paramdef>sampler2DShadow <parameter>sampler</parameter></paramdef>
-                <paramdef>vec4 <parameter>P</parameter></paramdef>
+                <paramdef>vec3 <parameter>P</parameter></paramdef>
                 <paramdef>float <parameter>lod</parameter></paramdef>
                 <paramdef>ivec2 <parameter>offset</parameter></paramdef>
             </funcprototype>


### PR DESCRIPTION

Fixes #73.