### PR TITLE
Fix description of invalid operation with glBlitFrameBuffer

### DIFF
--- a/gl4/glBlitFramebuffer.xml
+++ b/gl4/glBlitFramebuffer.xml
@@ -252,9 +252,9 @@
             and the read buffer contains integer data.
         </para>
         <para>
-            <constant>GL_INVALID_OPERATION</constant> is generated if the
-            effective value of <constant>GL_SAMPLES</constant> for the read
-            and draw framebuffers is not identical.
+            <constant>GL_INVALID_OPERATION</constant> is generated if both the
+			read and draw framebuffers are multisampled, and their effective
+			values of <constant>GL_SAMPLES</constant> are not identical.
         </para>
         <para>
             <constant>GL_INVALID_OPERATION</constant> is generated if the


### PR DESCRIPTION
glBlitFrameBuffer() does not produce GL_INVALID_OPERATION when read and draw framebuffers have different values of GL_SAMPLES *if* only one of them is multisampled.

See section 18.3.2 Blitting Pixel Rectangles