### PR TITLE
Fixing typos for glConvolutionFilter* documentations

### DIFF
--- a/gl2.1/glConvolutionFilter1D.xml
+++ b/gl2.1/glConvolutionFilter1D.xml
@@ -393,15 +393,15 @@
             <constant>GL_MAX_CONVOLUTION_WIDTH</constant>.
         </para>
         <para>
-            <constant>GL_INVALID_OPERATION</constant> is generated if <parameter>format</parameter> is one of
+            <constant>GL_INVALID_OPERATION</constant> is generated if <parameter>type</parameter> is one of
             <constant>GL_UNSIGNED_BYTE_3_3_2</constant>,
             <constant>GL_UNSIGNED_BYTE_2_3_3_REV</constant>,
             <constant>GL_UNSIGNED_SHORT_5_6_5</constant>, or
             <constant>GL_UNSIGNED_SHORT_5_6_5_REV</constant>
-            and <parameter>type</parameter> is not <constant>GL_RGB</constant>.
+            and <parameter>format</parameter> is not <constant>GL_RGB</constant>.
         </para>
         <para>
-            <constant>GL_INVALID_OPERATION</constant> is generated if <parameter>format</parameter> is one of
+            <constant>GL_INVALID_OPERATION</constant> is generated if <parameter>type</parameter> is one of
             <constant>GL_UNSIGNED_SHORT_4_4_4_4</constant>,
             <constant>GL_UNSIGNED_SHORT_4_4_4_4_REV</constant>,
             <constant>GL_UNSIGNED_SHORT_5_5_5_1</constant>,
@@ -410,7 +410,7 @@
             <constant>GL_UNSIGNED_INT_8_8_8_8_REV</constant>,
             <constant>GL_UNSIGNED_INT_10_10_10_2</constant>, or
             <constant>GL_UNSIGNED_INT_2_10_10_10_REV</constant>
-            and <parameter>type</parameter> is neither <constant>GL_RGBA</constant> nor <constant>GL_BGRA</constant>.
+            and <parameter>format</parameter> is neither <constant>GL_RGBA</constant> nor <constant>GL_BGRA</constant>.
         </para>
         <para>
             <constant>GL_INVALID_OPERATION</constant> is generated if a non-zero buffer object name is bound to the

--- a/gl2.1/glConvolutionFilter2D.xml
+++ b/gl2.1/glConvolutionFilter2D.xml
@@ -415,7 +415,7 @@
             <constant>GL_MAX_CONVOLUTION_HEIGHT</constant>.
         </para>
         <para>
-            <constant>GL_INVALID_OPERATION</constant> is generated if <parameter>height</parameter> is one of
+            <constant>GL_INVALID_OPERATION</constant> is generated if <parameter>type</parameter> is one of
             <constant>GL_UNSIGNED_BYTE_3_3_2</constant>,
             <constant>GL_UNSIGNED_BYTE_2_3_3_REV</constant>,
             <constant>GL_UNSIGNED_SHORT_5_6_5</constant>, or
@@ -423,7 +423,7 @@
             and <parameter>format</parameter> is not <constant>GL_RGB</constant>.
         </para>
         <para>
-            <constant>GL_INVALID_OPERATION</constant> is generated if <parameter>height</parameter> is one of
+            <constant>GL_INVALID_OPERATION</constant> is generated if <parameter>type</parameter> is one of
             <constant>GL_UNSIGNED_SHORT_4_4_4_4</constant>,
             <constant>GL_UNSIGNED_SHORT_4_4_4_4_REV</constant>,
             <constant>GL_UNSIGNED_SHORT_5_5_5_1</constant>,


### PR DESCRIPTION
There is some inversions in the error cases listing for the glConvolutionFilter1D and glConvolutionFilter2D functions.