### PR TITLE
Fix typo in ES versions of glGetProgramiv

### DIFF
--- a/es3.1/glGetProgramiv.xml
+++ b/es3.1/glGetProgramiv.xml
@@ -256,7 +256,7 @@
             </para>
             <para> <parameter>params</parameter> returns 
 			<constant>GL_TRUE</constant> if the program has been flagged
-			for use as a separable program object that can be found to 
+			for use as a separable program object that can be bound to 
 			individual shader stages with 
 			<citerefentry><refentrytitle>glUseProgramStages</refentrytitle></citerefentry>.</para>
         </listitem>

--- a/es3.1/html/glGetProgramiv.xhtml
+++ b/es3.1/html/glGetProgramiv.xhtml
@@ -301,7 +301,7 @@
             </p>
               <p> <em class="parameter"><code>params</code></em> returns 
 			<code class="constant">GL_TRUE</code> if the program has been flagged
-			for use as a separable program object that can be found to 
+			for use as a separable program object that can be bound to 
 			individual shader stages with 
 			<a class="citerefentry" href="glUseProgramStages.xhtml"><span class="citerefentry"><span class="refentrytitle">glUseProgramStages</span></span></a>.</p>
             </dd>

--- a/es3/glGetProgramiv.xml
+++ b/es3/glGetProgramiv.xml
@@ -302,7 +302,7 @@
             </para>
             <para> <parameter>params</parameter> returns 
 			<constant>GL_TRUE</constant> if the program has been flagged
-			for use as a separable program object that can be found to 
+			for use as a separable program object that can be bound to 
 			individual shader stages with 
 			<citerefentry><refentrytitle>glUseProgramStages</refentrytitle></citerefentry>.</para>
         </listitem>

--- a/es3/html/glGetProgramiv.xhtml
+++ b/es3/html/glGetProgramiv.xhtml
@@ -356,7 +356,7 @@
             </p>
               <p> <em class="parameter"><code>params</code></em> returns 
 			<code class="constant">GL_TRUE</code> if the program has been flagged
-			for use as a separable program object that can be found to 
+			for use as a separable program object that can be bound to 
 			individual shader stages with 
 			<a class="citerefentry" href="glUseProgramStages.xhtml"><span class="citerefentry"><span class="refentrytitle">glUseProgramStages</span></span></a>.</p>
             </dd>


### PR DESCRIPTION
"found" should have been "bound" in a few files.