### PR TITLE
Missing xlink namespace restored.

### DIFF
--- a/gl4/glGetVertexArrayiv.xml
+++ b/gl4/glGetVertexArrayiv.xml
@@ -125,6 +125,6 @@
     <para>Copyright <trademark class="copyright"/> 2014 Khronos Group. This
     material may be distributed subject to the terms and conditions set forth
     in the Open Publication License, v 1.0, 8 June 1999. <link
-    xlink:href="http://opencontent.org/openpub/">http://opencontent.org/openpub/</link>.</para>
+    xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://opencontent.org/openpub/">http://opencontent.org/openpub/</link>.</para>
   </refsect1>
 </refentry>


### PR DESCRIPTION
There is a missing XLink namespace specifier on this file. This PR fixes this.