### PR TITLE
Fix Indirect command struct definitions

### DIFF
--- a/gl4/glDrawArraysIndirect.xml
+++ b/gl4/glDrawArraysIndirect.xml
@@ -73,13 +73,13 @@
             that takes the form (in C):
             <programlisting>    typedef  struct {
         uint  count;
-        uint  primCount;
+        uint  instanceCount;
         uint  first;
         uint  baseInstance;
     } DrawArraysIndirectCommand;
 
     const DrawArraysIndirectCommand *cmd = (const DrawArraysIndirectCommand *)indirect;
-    glDrawArraysInstancedBaseInstance(mode, cmd-&gt;first, cmd-&gt;count, cmd-&gt;primCount, cmd-&gt;baseInstance);</programlisting>
+    glDrawArraysInstancedBaseInstance(mode, cmd-&gt;first, cmd-&gt;count, cmd-&gt;instanceCount, cmd-&gt;baseInstance);</programlisting>
         </para>
         <para>
             If a buffer is bound to the <constant>GL_DRAW_INDIRECT_BUFFER</constant> binding at the time

--- a/gl4/glDrawElementsIndirect.xml
+++ b/gl4/glDrawElementsIndirect.xml
@@ -84,9 +84,9 @@
         </para>
             <programlisting>    typedef  struct {
         uint  count;
-        uint  primCount;
+        uint  instanceCount;
         uint  firstIndex;
-        uint  baseVertex;
+        int  baseVertex;
         uint  baseInstance;
     } DrawElementsIndirectCommand;</programlisting>
         <para>
@@ -99,7 +99,7 @@
                                                       cmd-&gt;count,
                                                       type,
                                                       cmd-&gt;firstIndex * size-of-type,
-                                                      cmd-&gt;primCount,
+                                                      cmd-&gt;instanceCount,
                                                       cmd-&gt;baseVertex,
                                                       cmd-&gt;baseInstance);
     }</programlisting>

--- a/gl4/glMultiDrawElementsIndirect.xml
+++ b/gl4/glMultiDrawElementsIndirect.xml
@@ -104,7 +104,7 @@
         uint  count;
         uint  instanceCount;
         uint  firstIndex;
-        uint  baseVertex;
+        int  baseVertex;
         uint  baseInstance;
     } DrawElementsIndirectCommand;</programlisting>
         </para>

--- a/gl4/html/glDrawArraysIndirect.xhtml
+++ b/gl4/html/glDrawArraysIndirect.xhtml
@@ -102,13 +102,13 @@
             </p>
         <pre class="programlisting">    typedef  struct {
         uint  count;
-        uint  primCount;
+        uint  instanceCount;
         uint  first;
         uint  baseInstance;
     } DrawArraysIndirectCommand;
 
     const DrawArraysIndirectCommand *cmd = (const DrawArraysIndirectCommand *)indirect;
-    glDrawArraysInstancedBaseInstance(mode, cmd-&gt;first, cmd-&gt;count, cmd-&gt;primCount, cmd-&gt;baseInstance);</pre>
+    glDrawArraysInstancedBaseInstance(mode, cmd-&gt;first, cmd-&gt;count, cmd-&gt;instanceCount, cmd-&gt;baseInstance);</pre>
         <p>
         </p>
         <p>

--- a/gl4/html/glDrawElementsIndirect.xhtml
+++ b/gl4/html/glDrawElementsIndirect.xhtml
@@ -118,9 +118,9 @@
         </p>
         <pre class="programlisting">    typedef  struct {
         uint  count;
-        uint  primCount;
+        uint  instanceCount;
         uint  firstIndex;
-        uint  baseVertex;
+        int  baseVertex;
         uint  baseInstance;
     } DrawElementsIndirectCommand;</pre>
         <p>
@@ -134,7 +134,7 @@
                                                       cmd-&gt;count,
                                                       type,
                                                       cmd-&gt;firstIndex * size-of-type,
-                                                      cmd-&gt;primCount,
+                                                      cmd-&gt;instanceCount,
                                                       cmd-&gt;baseVertex,
                                                       cmd-&gt;baseInstance);
     }</pre>

--- a/gl4/html/glMultiDrawElementsIndirect.xhtml
+++ b/gl4/html/glMultiDrawElementsIndirect.xhtml
@@ -154,7 +154,7 @@
         uint  count;
         uint  instanceCount;
         uint  firstIndex;
-        uint  baseVertex;
+        int  baseVertex;
         uint  baseInstance;
     } DrawElementsIndirectCommand;</pre>
         <p>


### PR DESCRIPTION
The documentation differs from the GL 4.5 (or equivalently 4.6) spec in its definition of both DrawArraysIndirectCommand and DrawElementsIndirectCommand. In particular:

- DrawArraysIndirectCommand has no `primCount` member, but rather an `instanceCount` member, which in turn matches that of glDrawArraysInstancedBaseInstance; c.f. [GL4.5 §10.4, p353](https://www.khronos.org/registry/OpenGL/specs/gl/glspec45.core.pdf#page=374) or [GL4.6 §10.4, p366](https://www.khronos.org/registry/OpenGL/specs/gl/glspec46.core.pdf#page=388).
- As above for DrawElementsIndirectCommand. Moreover, `baseVertex` is an int, not a uint; c.f. [GL4.5 §10.4, p359](https://www.khronos.org/registry/OpenGL/specs/gl/glspec45.core.pdf#page=380) or [GL4.6 §10.4, p373](https://www.khronos.org/registry/OpenGL/specs/gl/glspec46.core.pdf#page=395).