### PR TITLE
Fix gsampler2DDArray typo for textureQueryLod and textureQueryLevels

### DIFF
--- a/gl4/html/textureQueryLevels.xhtml
+++ b/gl4/html/textureQueryLevels.xhtml
@@ -77,7 +77,7 @@
               <td>
                 <code class="funcdef">int <strong class="fsfunc">textureQueryLevels</strong>(</code>
               </td>
-              <td>gsampler2DDArray <var class="pdparam">sampler</var><code>)</code>;</td>
+              <td>gsampler2DArray <var class="pdparam">sampler</var><code>)</code>;</td>
             </tr>
           </table>
           <div class="funcprototype-spacer"> </div>

--- a/gl4/html/textureQueryLod.xhtml
+++ b/gl4/html/textureQueryLod.xhtml
@@ -97,7 +97,7 @@
               <td>
                 <code class="funcdef">vec2 <strong class="fsfunc">textureQueryLod</strong>(</code>
               </td>
-              <td>gsampler2DDArray <var class="pdparam">sampler</var>, </td>
+              <td>gsampler2DArray <var class="pdparam">sampler</var>, </td>
             </tr>
             <tr>
               <td> </td>

--- a/gl4/textureQueryLevels.xml
+++ b/gl4/textureQueryLevels.xml
@@ -41,7 +41,7 @@
             </funcprototype>
             <funcprototype>
                 <funcdef>int <function>textureQueryLevels</function></funcdef>
-                <paramdef>gsampler2DDArray <parameter>sampler</parameter></paramdef>
+                <paramdef>gsampler2DArray <parameter>sampler</parameter></paramdef>
             </funcprototype>
             <funcprototype>
                 <funcdef>int <function>textureQueryLevels</function></funcdef>

--- a/gl4/textureQueryLod.xml
+++ b/gl4/textureQueryLod.xml
@@ -46,7 +46,7 @@
             </funcprototype>
             <funcprototype>
                 <funcdef>vec2 <function>textureQueryLod</function></funcdef>
-                <paramdef>gsampler2DDArray <parameter>sampler</parameter></paramdef>
+                <paramdef>gsampler2DArray <parameter>sampler</parameter></paramdef>
                 <paramdef>vec2 <parameter>P</parameter></paramdef>
             </funcprototype>
             <funcprototype>


### PR DESCRIPTION
`gsampler2DDArray` doesn't exist; it should be `gsampler2DArray`.  This typo was present for `textureQueryLod` and `textureQueryLevels`.