### PR TITLE
Update minimum GLSL version of 'isinf' to 1.3

### DIFF
--- a/gl4/isinf.xml
+++ b/gl4/isinf.xml
@@ -54,7 +54,7 @@
                 <tbody>
                     <row>
                         <entry>isinf (genType)</entry>
-                        <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="version.xml" xpointer="xpointer(/*/*[@role='11']/*)"/>
+                        <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="version.xml" xpointer="xpointer(/*/*[@role='13']/*)"/>
                     </row>
                     <row>
                         <entry>isinf (genDType)</entry>


### PR DESCRIPTION
isinf doesn't appear in the GLSL spec until 1.3.

https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.1.20.pdf
https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.1.30.pdf

In practice this is enforced by some GLSL implementations (#version 110 will produce a shader which cannot call `isinf`)