### PR TITLE
Fix typo for MAX_VERTEX_TEXTURE_IMAGE_UNITS

### DIFF
--- a/gl4/glGet.xml
+++ b/gl4/glGet.xml
@@ -378,7 +378,7 @@
                 <listitem>
                     <para>
                         <parameter>data</parameter> returns one value, the maximum supported texture image units that
-                        can be used to access texture maps from the compute shader. The value may be at least 16.
+                        can be used to access texture maps from the compute shader. The value must be at least 16.
                         See <citerefentry><refentrytitle>glActiveTexture</refentrytitle></citerefentry>.
                     </para>
                 </listitem>

--- a/gl4/html/glGet.xhtml
+++ b/gl4/html/glGet.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title>glGet - OpenGL 4 Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="opengl-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.2"/>
     <script type="text/x-mathjax-config">
             MathJax.Hub.Config({
                 MathML: {
@@ -536,7 +536,7 @@
             <dd>
               <p>
                         <em class="parameter"><code>data</code></em> returns one value, the maximum supported texture image units that
-                        can be used to access texture maps from the compute shader. The value may be at least 16.
+                        can be used to access texture maps from the compute shader. The value must be at least 16.
                         See <a class="citerefentry" href="glActiveTexture.xhtml"><span class="citerefentry"><span class="refentrytitle">glActiveTexture</span></span></a>.
                     </p>
             </dd>


### PR DESCRIPTION
Fixes KhronosGroup/OpenGL-Registry#476