### PR TITLE
gl4: Rename samplerRect to sampler2DRect in textureSize

### DIFF
--- a/gl4/html/textureSize.xhtml
+++ b/gl4/html/textureSize.xhtml
@@ -149,7 +149,7 @@
               <td>
                 <code class="funcdef">ivec2 <strong class="fsfunc">textureSize</strong>(</code>
               </td>
-              <td>gsamplerRect <var class="pdparam">sampler</var><code>)</code>;</td>
+              <td>gsampler2DRect <var class="pdparam">sampler</var><code>)</code>;</td>
             </tr>
           </table>
           <div class="funcprototype-spacer"> </div>
@@ -158,7 +158,7 @@
               <td>
                 <code class="funcdef">ivec2 <strong class="fsfunc">textureSize</strong>(</code>
               </td>
-              <td>samplerRectShadow <var class="pdparam">sampler</var><code>)</code>;</td>
+              <td>sampler2DRectShadow <var class="pdparam">sampler</var><code>)</code>;</td>
             </tr>
           </table>
           <div class="funcprototype-spacer"> </div>
@@ -370,7 +370,7 @@
                 <td style="text-align: center; border-bottom: 2px solid ; ">✔</td>
               </tr>
               <tr>
-                <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">textureSize (samplerBuffer, samplerRect{Shadow})</td>
+                <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">textureSize (samplerBuffer, sampler2DRect{Shadow})</td>
                 <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
                 <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>
                 <td style="text-align: center; border-right: 2px solid ; border-bottom: 2px solid ; ">-</td>

--- a/gl4/textureSize.xml
+++ b/gl4/textureSize.xml
@@ -66,11 +66,11 @@
             </funcprototype>
             <funcprototype>
                 <funcdef>ivec2 <function>textureSize</function></funcdef>
-                <paramdef>gsamplerRect <parameter>sampler</parameter></paramdef>
+                <paramdef>gsampler2DRect <parameter>sampler</parameter></paramdef>
             </funcprototype>
             <funcprototype>
                 <funcdef>ivec2 <function>textureSize</function></funcdef>
-                <paramdef>samplerRectShadow <parameter>sampler</parameter></paramdef>
+                <paramdef>sampler2DRectShadow <parameter>sampler</parameter></paramdef>
             </funcprototype>
             <funcprototype>
                 <funcdef>ivec2 <function>textureSize</function></funcdef>
@@ -143,7 +143,7 @@
                         <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="version.xml" xpointer="xpointer(/*/*[@role='13']/*)"/>
                     </row>
                     <row>
-                        <entry>textureSize (samplerBuffer, samplerRect{Shadow})</entry>
+                        <entry>textureSize (samplerBuffer, sampler2DRect{Shadow})</entry>
                         <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="version.xml" xpointer="xpointer(/*/*[@role='14']/*)"/>
                     </row>
                     <row>


### PR DESCRIPTION
The samplerRect type doesn't exist and is actually sampler2DRect.