### PR TITLE
Small fixes from docs.gl

### DIFF
--- a/es3.0/glRenderbufferStorageMultisample.xml
+++ b/es3.0/glRenderbufferStorageMultisample.xml
@@ -86,7 +86,7 @@
             Both <parameter>width</parameter> and <parameter>height</parameter> must be less than or equal to the value of
             <constant>GL_MAX_RENDERBUFFER_SIZE</constant>. <parameter>samples</parameter> specifies the number of samples to be used
             for the renderbuffer object's image. If <parameter>internalformat</parameter> is a signed or unsigned integer format then
-                        <parameter>samples</parameter> must be 0.  Otherwise, <parameter>samples</parameter> must be must be less than or equal to
+                        <parameter>samples</parameter> must be 0.  Otherwise, <parameter>samples</parameter> must be less than or equal to
                         the maximum number of samples supported for <parameter>internalformat</parameter>.
                         (see <citerefentry><refentrytitle>glGetInternalformativ</refentrytitle></citerefentry>).
         </para>

--- a/es3.0/gl_FragDepth.xml
+++ b/es3.0/gl_FragDepth.xml
@@ -33,7 +33,7 @@
             depth will be used (this value is contained in the z component of <citerefentry><refentrytitle>gl_FragCoord</refentrytitle></citerefentry>)
             otherwise, the value written to <varname>gl_FragDepth</varname> is used.
             If a shader statically assigns to <varname>gl_FragDepth</varname>, then the value of the fragment's depth
-            may be undefined for executions of the shader that take that path. That is, if the set of linked fragment
+            may be undefined for executions of the shader that don't take that path. That is, if the set of linked fragment
             shaders statically contain a write to <varname>gl_FragDepth</varname>, then it is responsible for always
             writing it.
         </para>

--- a/es3.0/html/glRenderbufferStorageMultisample.xhtml
+++ b/es3.0/html/glRenderbufferStorageMultisample.xhtml
@@ -135,7 +135,7 @@
             Both <em class="parameter"><code>width</code></em> and <em class="parameter"><code>height</code></em> must be less than or equal to the value of
             <code class="constant">GL_MAX_RENDERBUFFER_SIZE</code>. <em class="parameter"><code>samples</code></em> specifies the number of samples to be used
             for the renderbuffer object's image. If <em class="parameter"><code>internalformat</code></em> is a signed or unsigned integer format then
-                        <em class="parameter"><code>samples</code></em> must be 0.  Otherwise, <em class="parameter"><code>samples</code></em> must be must be less than or equal to
+                        <em class="parameter"><code>samples</code></em> must be 0.  Otherwise, <em class="parameter"><code>samples</code></em> must be less than or equal to
                         the maximum number of samples supported for <em class="parameter"><code>internalformat</code></em>.
                         (see <a class="citerefentry" href="glGetInternalformativ.xhtml"><span class="citerefentry"><span class="refentrytitle">glGetInternalformativ</span></span></a>).
         </p>

--- a/es3.0/html/gl_FragDepth.xhtml
+++ b/es3.0/html/gl_FragDepth.xhtml
@@ -37,7 +37,7 @@
             depth will be used (this value is contained in the z component of <a class="citerefentry" href="gl_FragCoord.xhtml"><span class="citerefentry"><span class="refentrytitle">gl_FragCoord</span></span></a>)
             otherwise, the value written to <code class="varname">gl_FragDepth</code> is used.
             If a shader statically assigns to <code class="varname">gl_FragDepth</code>, then the value of the fragment's depth
-            may be undefined for executions of the shader that take that path. That is, if the set of linked fragment
+            may be undefined for executions of the shader that don't take that path. That is, if the set of linked fragment
             shaders statically contain a write to <code class="varname">gl_FragDepth</code>, then it is responsible for always
             writing it.
         </p>

--- a/es3.1/glDeleteProgramPipelines.xml
+++ b/es3.1/glDeleteProgramPipelines.xml
@@ -81,7 +81,6 @@
             <citerefentry><refentrytitle>glGenProgramPipelines</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>glBindProgramPipeline</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>glIsProgramPipeline</refentrytitle></citerefentry>,
-            <citerefentry><refentrytitle>glUseShaderPrograms</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>glUseProgram</refentrytitle></citerefentry>
         </para>
     </refsect1>

--- a/es3.1/glGenProgramPipelines.xml
+++ b/es3.1/glGenProgramPipelines.xml
@@ -83,7 +83,6 @@
             <citerefentry><refentrytitle>glDeleteProgramPipelines</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>glBindProgramPipeline</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>glIsProgramPipeline</refentrytitle></citerefentry>,
-            <citerefentry><refentrytitle>glUseShaderPrograms</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>glUseProgram</refentrytitle></citerefentry>
         </para>
     </refsect1>

--- a/es3.1/glRenderbufferStorageMultisample.xml
+++ b/es3.1/glRenderbufferStorageMultisample.xml
@@ -87,7 +87,7 @@
             Both <parameter>width</parameter> and <parameter>height</parameter> must be less than or equal to the value of
             <constant>GL_MAX_RENDERBUFFER_SIZE</constant>. <parameter>samples</parameter> specifies the number of samples to be used
             for the renderbuffer object's image. If <parameter>internalformat</parameter> is a signed or unsigned integer format then
-                        <parameter>samples</parameter> must be 0.  Otherwise, <parameter>samples</parameter> must be must be less than or equal to
+                        <parameter>samples</parameter> must be 0.  Otherwise, <parameter>samples</parameter> must be less than or equal to
                         the maximum number of samples supported for <parameter>internalformat</parameter>.
                         (see <citerefentry><refentrytitle>glGetInternalformativ</refentrytitle></citerefentry>).
         </para>

--- a/es3.1/gl_FragDepth.xml
+++ b/es3.1/gl_FragDepth.xml
@@ -33,7 +33,7 @@
             depth will be used (this value is contained in the z component of <citerefentry><refentrytitle>gl_FragCoord</refentrytitle></citerefentry>)
             otherwise, the value written to <varname>gl_FragDepth</varname> is used.
             If a shader statically assigns to <varname>gl_FragDepth</varname>, then the value of the fragment's depth
-            may be undefined for executions of the shader that take that path. That is, if the set of linked fragment
+            may be undefined for executions of the shader that don't take that path. That is, if the set of linked fragment
             shaders statically contain a write to <varname>gl_FragDepth</varname>, then it is responsible for always
             writing it.
         </para>

--- a/es3.1/html/glDeleteProgramPipelines.xhtml
+++ b/es3.1/html/glDeleteProgramPipelines.xhtml
@@ -142,7 +142,6 @@
             <a class="citerefentry" href="glGenProgramPipelines.xhtml"><span class="citerefentry"><span class="refentrytitle">glGenProgramPipelines</span></span></a>,
             <a class="citerefentry" href="glBindProgramPipeline.xhtml"><span class="citerefentry"><span class="refentrytitle">glBindProgramPipeline</span></span></a>,
             <a class="citerefentry" href="glIsProgramPipeline.xhtml"><span class="citerefentry"><span class="refentrytitle">glIsProgramPipeline</span></span></a>,
-            <a class="citerefentry" href="glUseShaderPrograms.xhtml"><span class="citerefentry"><span class="refentrytitle">glUseShaderPrograms</span></span></a>,
             <a class="citerefentry" href="glUseProgram.xhtml"><span class="citerefentry"><span class="refentrytitle">glUseProgram</span></span></a>
         </p>
       </div>

--- a/es3.1/html/glGenProgramPipelines.xhtml
+++ b/es3.1/html/glGenProgramPipelines.xhtml
@@ -144,7 +144,6 @@
             <a class="citerefentry" href="glDeleteProgramPipelines.xhtml"><span class="citerefentry"><span class="refentrytitle">glDeleteProgramPipelines</span></span></a>,
             <a class="citerefentry" href="glBindProgramPipeline.xhtml"><span class="citerefentry"><span class="refentrytitle">glBindProgramPipeline</span></span></a>,
             <a class="citerefentry" href="glIsProgramPipeline.xhtml"><span class="citerefentry"><span class="refentrytitle">glIsProgramPipeline</span></span></a>,
-            <a class="citerefentry" href="glUseShaderPrograms.xhtml"><span class="citerefentry"><span class="refentrytitle">glUseShaderPrograms</span></span></a>,
             <a class="citerefentry" href="glUseProgram.xhtml"><span class="citerefentry"><span class="refentrytitle">glUseProgram</span></span></a>
         </p>
       </div>

--- a/es3.1/html/glRenderbufferStorageMultisample.xhtml
+++ b/es3.1/html/glRenderbufferStorageMultisample.xhtml
@@ -135,7 +135,7 @@
             Both <em class="parameter"><code>width</code></em> and <em class="parameter"><code>height</code></em> must be less than or equal to the value of
             <code class="constant">GL_MAX_RENDERBUFFER_SIZE</code>. <em class="parameter"><code>samples</code></em> specifies the number of samples to be used
             for the renderbuffer object's image. If <em class="parameter"><code>internalformat</code></em> is a signed or unsigned integer format then
-                        <em class="parameter"><code>samples</code></em> must be 0.  Otherwise, <em class="parameter"><code>samples</code></em> must be must be less than or equal to
+                        <em class="parameter"><code>samples</code></em> must be 0.  Otherwise, <em class="parameter"><code>samples</code></em> must be less than or equal to
                         the maximum number of samples supported for <em class="parameter"><code>internalformat</code></em>.
                         (see <a class="citerefentry" href="glGetInternalformativ.xhtml"><span class="citerefentry"><span class="refentrytitle">glGetInternalformativ</span></span></a>).
         </p>

--- a/es3.1/html/gl_FragDepth.xhtml
+++ b/es3.1/html/gl_FragDepth.xhtml
@@ -37,7 +37,7 @@
             depth will be used (this value is contained in the z component of <a class="citerefentry" href="gl_FragCoord.xhtml"><span class="citerefentry"><span class="refentrytitle">gl_FragCoord</span></span></a>)
             otherwise, the value written to <code class="varname">gl_FragDepth</code> is used.
             If a shader statically assigns to <code class="varname">gl_FragDepth</code>, then the value of the fragment's depth
-            may be undefined for executions of the shader that take that path. That is, if the set of linked fragment
+            may be undefined for executions of the shader that don't take that path. That is, if the set of linked fragment
             shaders statically contain a write to <code class="varname">gl_FragDepth</code>, then it is responsible for always
             writing it.
         </p>

--- a/es3/glDebugMessageCallback.xml
+++ b/es3/glDebugMessageCallback.xml
@@ -20,7 +20,7 @@
             <funcprototype>
                 <funcdef>void <function>glDebugMessageCallback</function></funcdef>
                 <paramdef>DEBUGPROC <parameter>callback</parameter></paramdef>
-                <paramdef>void * <parameter>userParam</parameter></paramdef>
+                <paramdef>const void * <parameter>userParam</parameter></paramdef>
             </funcprototype>
         </funcsynopsis>
     </refsynopsisdiv>

--- a/es3/glDebugMessageCallback.xml
+++ b/es3/glDebugMessageCallback.xml
@@ -70,7 +70,7 @@
             <parameter>severity</parameter> associated with the message, and
             <parameter>length</parameter> set to the length of debug message
             whose character string is in the array pointed to by
-            <parameter>message</parameter> <parameter>userParam</parameter>
+            <parameter>message</parameter>. <parameter>userParam</parameter>
             will be set to the value passed in the
             <parameter>userParam</parameter> parameter to the most recent
             call to <function>glDebugMessageCallback</function>.

--- a/es3/glDeleteProgramPipelines.xml
+++ b/es3/glDeleteProgramPipelines.xml
@@ -81,7 +81,6 @@
             <citerefentry><refentrytitle>glGenProgramPipelines</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>glBindProgramPipeline</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>glIsProgramPipeline</refentrytitle></citerefentry>,
-            <citerefentry><refentrytitle>glUseShaderPrograms</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>glUseProgram</refentrytitle></citerefentry>
         </para>
     </refsect1>

--- a/es3/glGenProgramPipelines.xml
+++ b/es3/glGenProgramPipelines.xml
@@ -83,7 +83,6 @@
             <citerefentry><refentrytitle>glDeleteProgramPipelines</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>glBindProgramPipeline</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>glIsProgramPipeline</refentrytitle></citerefentry>,
-            <citerefentry><refentrytitle>glUseShaderPrograms</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>glUseProgram</refentrytitle></citerefentry>
         </para>
     </refsect1>

--- a/es3/glRenderbufferStorageMultisample.xml
+++ b/es3/glRenderbufferStorageMultisample.xml
@@ -87,7 +87,7 @@
             Both <parameter>width</parameter> and <parameter>height</parameter> must be less than or equal to the value of
             <constant>GL_MAX_RENDERBUFFER_SIZE</constant>. <parameter>samples</parameter> specifies the number of samples to be used
             for the renderbuffer object's image. If <parameter>internalformat</parameter> is a signed or unsigned integer format then
-                        <parameter>samples</parameter> must be 0.  Otherwise, <parameter>samples</parameter> must be must be less than or equal to
+                        <parameter>samples</parameter> must be 0.  Otherwise, <parameter>samples</parameter> must be less than or equal to
                         the maximum number of samples supported for <parameter>internalformat</parameter>.
                         (see <citerefentry><refentrytitle>glGetInternalformativ</refentrytitle></citerefentry>).
         </para>

--- a/es3/glTexBuffer.xml
+++ b/es3/glTexBuffer.xml
@@ -74,10 +74,6 @@
             <parameter>internalformat</parameter> specifies the storage
             format, and must be one of the following sized internal formats:
         </para>
-        <para>
-            <parameter>internalformat</parameter> specifies the storage
-            format, and must be one of the following sized internal formats:
-        </para>
         <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="texboformattable.xml"/>
         <para>
             When a buffer object is attached to a buffer texture, the buffer

--- a/es3/gl_FragDepth.xml
+++ b/es3/gl_FragDepth.xml
@@ -33,7 +33,7 @@
             depth will be used (this value is contained in the z component of <citerefentry><refentrytitle>gl_FragCoord</refentrytitle></citerefentry>)
             otherwise, the value written to <varname>gl_FragDepth</varname> is used.
             If a shader statically assigns to <varname>gl_FragDepth</varname>, then the value of the fragment's depth
-            may be undefined for executions of the shader that take that path. That is, if the set of linked fragment
+            may be undefined for executions of the shader that don't take that path. That is, if the set of linked fragment
             shaders statically contain a write to <varname>gl_FragDepth</varname>, then it is responsible for always
             writing it.
         </para>

--- a/es3/html/glDebugMessageCallback.xhtml
+++ b/es3/html/glDebugMessageCallback.xhtml
@@ -100,7 +100,7 @@
             <em class="parameter"><code>severity</code></em> associated with the message, and
             <em class="parameter"><code>length</code></em> set to the length of debug message
             whose character string is in the array pointed to by
-            <em class="parameter"><code>message</code></em> <em class="parameter"><code>userParam</code></em>
+            <em class="parameter"><code>message</code></em>. <em class="parameter"><code>userParam</code></em>
             will be set to the value passed in the
             <em class="parameter"><code>userParam</code></em> parameter to the most recent
             call to <code class="function">glDebugMessageCallback</code>.

--- a/es3/html/glDebugMessageCallback.xhtml
+++ b/es3/html/glDebugMessageCallback.xhtml
@@ -36,7 +36,7 @@
             </tr>
             <tr>
               <td> </td>
-              <td>void * <var class="pdparam">userParam</var><code>)</code>;</td>
+              <td>const void * <var class="pdparam">userParam</var><code>)</code>;</td>
             </tr>
           </table>
           <div class="funcprototype-spacer"> </div>

--- a/es3/html/glDeleteProgramPipelines.xhtml
+++ b/es3/html/glDeleteProgramPipelines.xhtml
@@ -147,7 +147,6 @@
             <a class="citerefentry" href="glGenProgramPipelines.xhtml"><span class="citerefentry"><span class="refentrytitle">glGenProgramPipelines</span></span></a>,
             <a class="citerefentry" href="glBindProgramPipeline.xhtml"><span class="citerefentry"><span class="refentrytitle">glBindProgramPipeline</span></span></a>,
             <a class="citerefentry" href="glIsProgramPipeline.xhtml"><span class="citerefentry"><span class="refentrytitle">glIsProgramPipeline</span></span></a>,
-            <a class="citerefentry" href="glUseShaderPrograms.xhtml"><span class="citerefentry"><span class="refentrytitle">glUseShaderPrograms</span></span></a>,
             <a class="citerefentry" href="glUseProgram.xhtml"><span class="citerefentry"><span class="refentrytitle">glUseProgram</span></span></a>
         </p>
       </div>

--- a/es3/html/glGenProgramPipelines.xhtml
+++ b/es3/html/glGenProgramPipelines.xhtml
@@ -149,7 +149,6 @@
             <a class="citerefentry" href="glDeleteProgramPipelines.xhtml"><span class="citerefentry"><span class="refentrytitle">glDeleteProgramPipelines</span></span></a>,
             <a class="citerefentry" href="glBindProgramPipeline.xhtml"><span class="citerefentry"><span class="refentrytitle">glBindProgramPipeline</span></span></a>,
             <a class="citerefentry" href="glIsProgramPipeline.xhtml"><span class="citerefentry"><span class="refentrytitle">glIsProgramPipeline</span></span></a>,
-            <a class="citerefentry" href="glUseShaderPrograms.xhtml"><span class="citerefentry"><span class="refentrytitle">glUseShaderPrograms</span></span></a>,
             <a class="citerefentry" href="glUseProgram.xhtml"><span class="citerefentry"><span class="refentrytitle">glUseProgram</span></span></a>
         </p>
       </div>

--- a/es3/html/glRenderbufferStorageMultisample.xhtml
+++ b/es3/html/glRenderbufferStorageMultisample.xhtml
@@ -135,7 +135,7 @@
             Both <em class="parameter"><code>width</code></em> and <em class="parameter"><code>height</code></em> must be less than or equal to the value of
             <code class="constant">GL_MAX_RENDERBUFFER_SIZE</code>. <em class="parameter"><code>samples</code></em> specifies the number of samples to be used
             for the renderbuffer object's image. If <em class="parameter"><code>internalformat</code></em> is a signed or unsigned integer format then
-                        <em class="parameter"><code>samples</code></em> must be 0.  Otherwise, <em class="parameter"><code>samples</code></em> must be must be less than or equal to
+                        <em class="parameter"><code>samples</code></em> must be 0.  Otherwise, <em class="parameter"><code>samples</code></em> must be less than or equal to
                         the maximum number of samples supported for <em class="parameter"><code>internalformat</code></em>.
                         (see <a class="citerefentry" href="glGetInternalformativ.xhtml"><span class="citerefentry"><span class="refentrytitle">glGetInternalformativ</span></span></a>).
         </p>

--- a/es3/html/glTexBuffer.xhtml
+++ b/es3/html/glTexBuffer.xhtml
@@ -111,10 +111,6 @@
             <em class="parameter"><code>internalformat</code></em> specifies the storage
             format, and must be one of the following sized internal formats:
         </p>
-        <p>
-            <em class="parameter"><code>internalformat</code></em> specifies the storage
-            format, and must be one of the following sized internal formats:
-        </p>
         <div class="informaltable">
           <table style="border-collapse: collapse; border-top: 2px solid ; border-bottom: 2px solid ; border-left: 2px solid ; border-right: 2px solid ; ">
             <colgroup>

--- a/es3/html/gl_FragDepth.xhtml
+++ b/es3/html/gl_FragDepth.xhtml
@@ -37,7 +37,7 @@
             depth will be used (this value is contained in the z component of <a class="citerefentry" href="gl_FragCoord.xhtml"><span class="citerefentry"><span class="refentrytitle">gl_FragCoord</span></span></a>)
             otherwise, the value written to <code class="varname">gl_FragDepth</code> is used.
             If a shader statically assigns to <code class="varname">gl_FragDepth</code>, then the value of the fragment's depth
-            may be undefined for executions of the shader that take that path. That is, if the set of linked fragment
+            may be undefined for executions of the shader that don't take that path. That is, if the set of linked fragment
             shaders statically contain a write to <code class="varname">gl_FragDepth</code>, then it is responsible for always
             writing it.
         </p>

--- a/gl4/glBindTexture.xml
+++ b/gl4/glBindTexture.xml
@@ -153,7 +153,7 @@
             <citerefentry><refentrytitle>glGet</refentrytitle></citerefentry> with argument <constant>GL_TEXTURE_BINDING_1D</constant>,
             <constant>GL_TEXTURE_BINDING_2D</constant>, <constant>GL_TEXTURE_BINDING_3D</constant>, <constant>GL_TEXTURE_BINDING_1D_ARRAY</constant>,
             <constant>GL_TEXTURE_BINDING_2D_ARRAY</constant>, <constant>GL_TEXTURE_BINDING_RECTANGLE</constant>,
-            <constant>GL_TEXTURE_BINDING_BUFFER</constant>, <constant>GL_TEXTURE_BINDING_CUBE_MAP</constant>, <constant>GL_TEXTURE_BINDING_CUBE_MAP</constant>,
+            <constant>GL_TEXTURE_BINDING_BUFFER</constant>, <constant>GL_TEXTURE_BINDING_CUBE_MAP</constant>,
             <constant>GL_TEXTURE_BINDING_CUBE_MAP_ARRAY</constant>,
             <constant>GL_TEXTURE_BINDING_2D_MULTISAMPLE</constant>,
             or <constant>GL_TEXTURE_BINDING_2D_MULTISAMPLE_ARRAY</constant>.

--- a/gl4/glDebugMessageCallback.xml
+++ b/gl4/glDebugMessageCallback.xml
@@ -70,7 +70,7 @@
             <parameter>severity</parameter> associated with the message, and
             <parameter>length</parameter> set to the length of debug message
             whose character string is in the array pointed to by
-            <parameter>message</parameter> <parameter>userParam</parameter>
+            <parameter>message</parameter>. <parameter>userParam</parameter>
             will be set to the value passed in the
             <parameter>userParam</parameter> parameter to the most recent
             call to <function>glDebugMessageCallback</function>.

--- a/gl4/glFramebufferTexture.xml
+++ b/gl4/glFramebufferTexture.xml
@@ -183,7 +183,7 @@
         <para>
             If <parameter>texture</parameter> is non-zero, the specified
             <parameter>level</parameter> of the texture object named
-            <parameter>texture</parameter> is attached to the framebfufer
+            <parameter>texture</parameter> is attached to the framebuffer
             attachment point named by <parameter>attachment</parameter>. For
             <function>glFramebufferTexture1D</function>,
             <function>glFramebufferTexture2D</function>, and

--- a/gl4/glGet.xml
+++ b/gl4/glGet.xml
@@ -1839,6 +1839,15 @@
                 </listitem>
             </varlistentry>
             <varlistentry>
+                <term><constant>GL_SAMPLE_MASK_VALUE</constant></term>
+                <listitem>
+                    <para>
+                        <parameter>params</parameter> returns one value indicating the current sample mask value.
+                        See <citerefentry><refentrytitle>glSampleMaski</refentrytitle></citerefentry>.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
                 <term><constant>GL_SAMPLER_BINDING</constant></term>
                 <listitem>
                     <para>

--- a/gl4/glGet.xml
+++ b/gl4/glGet.xml
@@ -2303,16 +2303,6 @@
                 </listitem>
             </varlistentry>
             <varlistentry>
-                <term><constant>GL_TEXTURE_BINDING_BUFFER</constant></term>
-                <listitem>
-                    <para>
-                        <parameter>data</parameter> returns a single value, the name of the buffer object
-                        currently bound to the <constant>GL_TEXTURE_BUFFER</constant> buffer binding point. The initial value is 0.
-                        See <citerefentry><refentrytitle>glBindBuffer</refentrytitle></citerefentry>.
-                    </para>
-                </listitem>
-            </varlistentry>
-            <varlistentry>
                 <term><constant>GL_TEXTURE_BUFFER_OFFSET_ALIGNMENT</constant></term>
                 <listitem>
                     <para>

--- a/gl4/glGetProgram.xml
+++ b/gl4/glGetProgram.xml
@@ -57,7 +57,7 @@
             <constant>GL_ACTIVE_UNIFORM_BLOCKS</constant>,
             <constant>GL_ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH</constant>,
             <constant>GL_ACTIVE_UNIFORM_MAX_LENGTH</constant>,
-            <constant>GL_COMPUTE_WORK_GROUP_SIZE</constant>
+            <constant>GL_COMPUTE_WORK_GROUP_SIZE</constant>,
             <constant>GL_PROGRAM_BINARY_LENGTH</constant>,
             <constant>GL_TRANSFORM_FEEDBACK_BUFFER_MODE</constant>,
             <constant>GL_TRANSFORM_FEEDBACK_VARYINGS</constant>,

--- a/gl4/glGetQueryObject.xml
+++ b/gl4/glGetQueryObject.xml
@@ -114,8 +114,12 @@
             <term><parameter>pname</parameter></term>
             <listitem>
                 <para>
-                    Specifies the symbolic name of a query object parameter.
-		    Accepted values are <constant>GL_QUERY_RESULT</constant> or <constant>GL_QUERY_RESULT_AVAILABLE</constant>.
+                    Specifies the symbolic name of a query object
+                    parameter.  Accepted values are
+                    <constant>GL_QUERY_RESULT</constant>,
+                    <constant>GL_QUERY_RESULT_AVAILABLE</constant>,
+                    <constant>GL_QUERY_RESULT_NO_WAIT</constant>, or
+                    <constant>GL_QUERY_TARGET</constant>.
                 </para>
             </listitem>
         </varlistentry>
@@ -180,6 +184,14 @@
                         If a delay would occur waiting for the query result, <constant>GL_FALSE</constant> is returned.
                         Otherwise, <constant>GL_TRUE</constant> is returned, which also indicates that the results of all
                         previous queries are available as well.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><constant>GL_QUERY_TARGET</constant></term>
+                <listitem>
+                    <para>
+                        <parameter>params</parameter> or <parameter>buffer</parameter> returns the query object's target.
                     </para>
                 </listitem>
             </varlistentry>

--- a/gl4/glTexBuffer.xml
+++ b/gl4/glTexBuffer.xml
@@ -91,10 +91,6 @@
             <parameter>internalformat</parameter> specifies the storage
             format, and must be one of the following sized internal formats:
         </para>
-        <para>
-            <parameter>internalformat</parameter> specifies the storage
-            format, and must be one of the following sized internal formats:
-        </para>
         <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="texboformattable.xml"/>
         <para>
             When a buffer object is attached to a buffer texture, the buffer

--- a/gl4/gl_FragDepth.xml
+++ b/gl4/gl_FragDepth.xml
@@ -33,7 +33,7 @@
             depth will be used (this value is contained in the z component of <citerefentry><refentrytitle>gl_FragCoord</refentrytitle></citerefentry>)
             otherwise, the value written to <varname>gl_FragDepth</varname> is used.
             If a shader statically assigns to <varname>gl_FragDepth</varname>, then the value of the fragment's depth
-            may be undefined for executions of the shader that take that path. That is, if the set of linked fragment
+            may be undefined for executions of the shader that don't take that path. That is, if the set of linked fragment
             shaders statically contain a write to <varname>gl_FragDepth</varname>, then it is responsible for always
             writing it.
         </para>

--- a/gl4/html/glBindTexture.xhtml
+++ b/gl4/html/glBindTexture.xhtml
@@ -180,7 +180,7 @@
             <a class="citerefentry" href="glGet.xhtml"><span class="citerefentry"><span class="refentrytitle">glGet</span></span></a> with argument <code class="constant">GL_TEXTURE_BINDING_1D</code>,
             <code class="constant">GL_TEXTURE_BINDING_2D</code>, <code class="constant">GL_TEXTURE_BINDING_3D</code>, <code class="constant">GL_TEXTURE_BINDING_1D_ARRAY</code>,
             <code class="constant">GL_TEXTURE_BINDING_2D_ARRAY</code>, <code class="constant">GL_TEXTURE_BINDING_RECTANGLE</code>,
-            <code class="constant">GL_TEXTURE_BINDING_BUFFER</code>, <code class="constant">GL_TEXTURE_BINDING_CUBE_MAP</code>, <code class="constant">GL_TEXTURE_BINDING_CUBE_MAP</code>,
+            <code class="constant">GL_TEXTURE_BINDING_BUFFER</code>, <code class="constant">GL_TEXTURE_BINDING_CUBE_MAP</code>,
             <code class="constant">GL_TEXTURE_BINDING_CUBE_MAP_ARRAY</code>,
             <code class="constant">GL_TEXTURE_BINDING_2D_MULTISAMPLE</code>,
             or <code class="constant">GL_TEXTURE_BINDING_2D_MULTISAMPLE_ARRAY</code>.

--- a/gl4/html/glDebugMessageCallback.xhtml
+++ b/gl4/html/glDebugMessageCallback.xhtml
@@ -100,7 +100,7 @@
             <em class="parameter"><code>severity</code></em> associated with the message, and
             <em class="parameter"><code>length</code></em> set to the length of debug message
             whose character string is in the array pointed to by
-            <em class="parameter"><code>message</code></em> <em class="parameter"><code>userParam</code></em>
+            <em class="parameter"><code>message</code></em>. <em class="parameter"><code>userParam</code></em>
             will be set to the value passed in the
             <em class="parameter"><code>userParam</code></em> parameter to the most recent
             call to <code class="function">glDebugMessageCallback</code>.

--- a/gl4/html/glFramebufferTexture.xhtml
+++ b/gl4/html/glFramebufferTexture.xhtml
@@ -303,7 +303,7 @@
         <p>
             If <em class="parameter"><code>texture</code></em> is non-zero, the specified
             <em class="parameter"><code>level</code></em> of the texture object named
-            <em class="parameter"><code>texture</code></em> is attached to the framebfufer
+            <em class="parameter"><code>texture</code></em> is attached to the framebuffer
             attachment point named by <em class="parameter"><code>attachment</code></em>. For
             <code class="function">glFramebufferTexture1D</code>,
             <code class="function">glFramebufferTexture2D</code>, and

--- a/gl4/html/glGet.xhtml
+++ b/gl4/html/glGet.xhtml
@@ -2263,6 +2263,17 @@
             </dd>
             <dt>
               <span class="term">
+                <code class="constant">GL_SAMPLE_MASK_VALUE</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                        <em class="parameter"><code>params</code></em> returns one value indicating the current sample mask value.
+                        See <a class="citerefentry" href="glSampleMaski.xhtml"><span class="citerefentry"><span class="refentrytitle">glSampleMaski</span></span></a>.
+                    </p>
+            </dd>
+            <dt>
+              <span class="term">
                 <code class="constant">GL_SAMPLER_BINDING</code>
               </span>
             </dt>

--- a/gl4/html/glGet.xhtml
+++ b/gl4/html/glGet.xhtml
@@ -2809,18 +2809,6 @@
             </dd>
             <dt>
               <span class="term">
-                <code class="constant">GL_TEXTURE_BINDING_BUFFER</code>
-              </span>
-            </dt>
-            <dd>
-              <p>
-                        <em class="parameter"><code>data</code></em> returns a single value, the name of the buffer object
-                        currently bound to the <code class="constant">GL_TEXTURE_BUFFER</code> buffer binding point. The initial value is 0.
-                        See <a class="citerefentry" href="glBindBuffer.xhtml"><span class="citerefentry"><span class="refentrytitle">glBindBuffer</span></span></a>.
-                    </p>
-            </dd>
-            <dt>
-              <span class="term">
                 <code class="constant">GL_TEXTURE_BUFFER_OFFSET_ALIGNMENT</code>
               </span>
             </dt>

--- a/gl4/html/glGetProgram.xhtml
+++ b/gl4/html/glGetProgram.xhtml
@@ -83,7 +83,7 @@
             <code class="constant">GL_ACTIVE_UNIFORM_BLOCKS</code>,
             <code class="constant">GL_ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH</code>,
             <code class="constant">GL_ACTIVE_UNIFORM_MAX_LENGTH</code>,
-            <code class="constant">GL_COMPUTE_WORK_GROUP_SIZE</code>
+            <code class="constant">GL_COMPUTE_WORK_GROUP_SIZE</code>,
             <code class="constant">GL_PROGRAM_BINARY_LENGTH</code>,
             <code class="constant">GL_TRANSFORM_FEEDBACK_BUFFER_MODE</code>,
             <code class="constant">GL_TRANSFORM_FEEDBACK_VARYINGS</code>,

--- a/gl4/html/glGetQueryObject.xhtml
+++ b/gl4/html/glGetQueryObject.xhtml
@@ -232,8 +232,12 @@
             </dt>
             <dd>
               <p>
-                    Specifies the symbolic name of a query object parameter.
-		    Accepted values are <code class="constant">GL_QUERY_RESULT</code> or <code class="constant">GL_QUERY_RESULT_AVAILABLE</code>.
+                    Specifies the symbolic name of a query object
+                    parameter.  Accepted values are
+                    <code class="constant">GL_QUERY_RESULT</code>,
+                    <code class="constant">GL_QUERY_RESULT_AVAILABLE</code>,
+                    <code class="constant">GL_QUERY_RESULT_NO_WAIT</code>, or
+                    <code class="constant">GL_QUERY_TARGET</code>.
                 </p>
             </dd>
             <dt>
@@ -315,6 +319,16 @@
                         If a delay would occur waiting for the query result, <code class="constant">GL_FALSE</code> is returned.
                         Otherwise, <code class="constant">GL_TRUE</code> is returned, which also indicates that the results of all
                         previous queries are available as well.
+                    </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <code class="constant">GL_QUERY_TARGET</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                        <em class="parameter"><code>params</code></em> or <em class="parameter"><code>buffer</code></em> returns the query object's target.
                     </p>
             </dd>
           </dl>

--- a/gl4/html/glTexBuffer.xhtml
+++ b/gl4/html/glTexBuffer.xhtml
@@ -142,10 +142,6 @@
             <em class="parameter"><code>internalformat</code></em> specifies the storage
             format, and must be one of the following sized internal formats:
         </p>
-        <p>
-            <em class="parameter"><code>internalformat</code></em> specifies the storage
-            format, and must be one of the following sized internal formats:
-        </p>
         <div class="informaltable">
           <table style="border-collapse: collapse; border-top: 2px solid ; border-bottom: 2px solid ; border-left: 2px solid ; border-right: 2px solid ; ">
             <colgroup>

--- a/gl4/html/gl_FragDepth.xhtml
+++ b/gl4/html/gl_FragDepth.xhtml
@@ -37,7 +37,7 @@
             depth will be used (this value is contained in the z component of <a class="citerefentry" href="gl_FragCoord.xhtml"><span class="citerefentry"><span class="refentrytitle">gl_FragCoord</span></span></a>)
             otherwise, the value written to <code class="varname">gl_FragDepth</code> is used.
             If a shader statically assigns to <code class="varname">gl_FragDepth</code>, then the value of the fragment's depth
-            may be undefined for executions of the shader that take that path. That is, if the set of linked fragment
+            may be undefined for executions of the shader that don't take that path. That is, if the set of linked fragment
             shaders statically contain a write to <code class="varname">gl_FragDepth</code>, then it is responsible for always
             writing it.
         </p>

--- a/gl4/html/textureGather.xhtml
+++ b/gl4/html/textureGather.xhtml
@@ -268,7 +268,7 @@
         <p>
     </p>
         <p>
-        If specified, the value of <em class="parameter"><code>comp</code></em> must ba constant integer expression with a value
+        If specified, the value of <em class="parameter"><code>comp</code></em> must be a constant integer expression with a value
         of 0, 1, 2, or 3, identifying the x, y, z or w component of the four-component vector lookup result for each
         texel, respectively. If <em class="parameter"><code>comp</code></em> is not specified, it is treated as 0, selecting the x
         component of each texel to generate the result.

--- a/gl4/html/textureGatherOffset.xhtml
+++ b/gl4/html/textureGatherOffset.xhtml
@@ -242,7 +242,7 @@
         and <code class="constant">GL_MAX_PROGRAM_TEXTURE_GATHER_OFFSET</code>, respectively.
     </p>
         <p>
-        If specified, the value of <em class="parameter"><code>comp</code></em> must ba constant integer expression with a value
+        If specified, the value of <em class="parameter"><code>comp</code></em> must be a constant integer expression with a value
         of 0, 1, 2, or 3, identifying the x, y, z or w component of the four-component vector lookup result for each
         texel, respectively. If <em class="parameter"><code>comp</code></em> is not specified, it is treated as 0, selecting the x
         component of each texel to generate the result.

--- a/gl4/textureGather.xml
+++ b/gl4/textureGather.xml
@@ -128,7 +128,7 @@
          Sample_i0_j0(P, base).comp);</programlisting>
     </para>
     <para>
-        If specified, the value of <parameter>comp</parameter> must ba constant integer expression with a value
+        If specified, the value of <parameter>comp</parameter> must be a constant integer expression with a value
         of 0, 1, 2, or 3, identifying the x, y, z or w component of the four-component vector lookup result for each
         texel, respectively. If <parameter>comp</parameter> is not specified, it is treated as 0, selecting the x
         component of each texel to generate the result.

--- a/gl4/textureGatherOffset.xml
+++ b/gl4/textureGatherOffset.xml
@@ -124,7 +124,7 @@
         and <constant>GL_MAX_PROGRAM_TEXTURE_GATHER_OFFSET</constant>, respectively.
     </para>
     <para>
-        If specified, the value of <parameter>comp</parameter> must ba constant integer expression with a value
+        If specified, the value of <parameter>comp</parameter> must be a constant integer expression with a value
         of 0, 1, 2, or 3, identifying the x, y, z or w component of the four-component vector lookup result for each
         texel, respectively. If <parameter>comp</parameter> is not specified, it is treated as 0, selecting the x
         component of each texel to generate the result.


### PR DESCRIPTION
I went through the docs.gl repo (https://github.com/BSVino/docs.gl), looking for local fixes. This is the majority of the small ones. They had a few larger updates which I'll file as issues to better explain stuff (VAO required in core, glTexStorage making immutable textures). A handful here are not direct ports but rather fixes after checking for completeness of a fix.

I don't think there should be any licensing or attribution issues since the original text comes from Khronos in the first place, and these are all very minor updates.

@oddhack let me know if the way I pointed at the source commits is fine or if you want something else here.

Courtesy ping to @BSVino for awareness. Let me know if you feel like there are any problems with doing this.