### PR TITLE
Remove "equal to" in the GL_INVALID_VALUE error of glGetActiveUniformsiv

### DIFF
--- a/es3.0/glGetActiveUniformsiv.xml
+++ b/es3.0/glGetActiveUniformsiv.xml
@@ -476,7 +476,7 @@
     <parameter>program</parameter> is not a program object.</para>
 
     <para><constant>GL_INVALID_VALUE</constant> is generated if
-    <parameter>uniformCount</parameter> is greater than or equal to the
+    <parameter>uniformCount</parameter> is greater than the
     value of <constant>GL_ACTIVE_UNIFORMS</constant> for
     <parameter>program</parameter>.</para>
 

--- a/es3.1/glGetActiveUniformsiv.xml
+++ b/es3.1/glGetActiveUniformsiv.xml
@@ -605,7 +605,7 @@
     <parameter>program</parameter> is not a program object.</para>
 
     <para><constant>GL_INVALID_VALUE</constant> is generated if
-    <parameter>uniformCount</parameter> is greater than or equal to the
+    <parameter>uniformCount</parameter> is greater than the
     value of <constant>GL_ACTIVE_UNIFORMS</constant> for
     <parameter>program</parameter>.</para>
 

--- a/es3/glGetActiveUniformsiv.xml
+++ b/es3/glGetActiveUniformsiv.xml
@@ -733,7 +733,7 @@
     <parameter>program</parameter> is not a program object.</para>
 
     <para><constant>GL_INVALID_VALUE</constant> is generated if
-    <parameter>uniformCount</parameter> is greater than or equal to the
+    <parameter>uniformCount</parameter> is greater than the
     value of <constant>GL_ACTIVE_UNIFORMS</constant> for
     <parameter>program</parameter>.</para>
 

--- a/es3/glTexStorage3D.xml
+++ b/es3/glTexStorage3D.xml
@@ -164,7 +164,7 @@
                         <parameter>depth</parameter> or <parameter>levels</parameter> are less than 1.
         </para>
         <para>
-            <constant>GL_INVALID_VALUE</constant> is generated if <parameter>target</parameter> is <constant>GL_TEXTURE_2D_ARRAY</constant> or <constant>GL_TEXTURE_CUBE_MAP_ARRAY</constant> and <parameter>width</parameter> and <parameter>height</parameter> are not equal, or
+            <constant>GL_INVALID_VALUE</constant> is generated if <parameter>target</parameter> is <constant>GL_TEXTURE_CUBE_MAP_ARRAY</constant> and <parameter>width</parameter> and <parameter>height</parameter> are not equal, or
                         <parameter>depth</parameter> is not a multiple of six.
         </para>
         <para>

--- a/es3/html/glTexStorage3D.xhtml
+++ b/es3/html/glTexStorage3D.xhtml
@@ -1627,7 +1627,7 @@
                         <em class="parameter"><code>depth</code></em> or <em class="parameter"><code>levels</code></em> are less than 1.
         </p>
         <p>
-            <code class="constant">GL_INVALID_VALUE</code> is generated if <em class="parameter"><code>target</code></em> is <code class="constant">GL_TEXTURE_2D_ARRAY</code> or <code class="constant">GL_TEXTURE_CUBE_MAP_ARRAY</code> and <em class="parameter"><code>width</code></em> and <em class="parameter"><code>height</code></em> are not equal, or
+            <code class="constant">GL_INVALID_VALUE</code> is generated if <em class="parameter"><code>target</code></em> is <code class="constant">GL_TEXTURE_CUBE_MAP_ARRAY</code> and <em class="parameter"><code>width</code></em> and <em class="parameter"><code>height</code></em> are not equal, or
                         <em class="parameter"><code>depth</code></em> is not a multiple of six.
         </p>
         <p>

--- a/gl4/glGetActiveUniformsiv.xml
+++ b/gl4/glGetActiveUniformsiv.xml
@@ -784,7 +784,7 @@
     <parameter>program</parameter> is not a program object.</para>
 
     <para><constant>GL_INVALID_VALUE</constant> is generated if
-    <parameter>uniformCount</parameter> is greater than or equal to the
+    <parameter>uniformCount</parameter> is greater than the
     value of <constant>GL_ACTIVE_UNIFORMS</constant> for
     <parameter>program</parameter>.</para>
 


### PR DESCRIPTION
The document of `glGetActiveUniformsiv` states that GL_INVALID_VALUE is generated if `uniformCount` is greater than or *equal to* the value of GL_ACTIVE_UNIFORMS for program. 

However, it's reasonable for OpenGL programs to give a value of `uniformCount` equaling the number of active uniforms in a specified shader program. This is because `uniformCount` specifies the length of the uniform array passed to `glGetActiveUniformsiv`. As long as this value does not exceed (i.e., is greater than) the actual number of active uniform variables, things should be fine.