### PR TITLE
gl4/glBlitFramebuffer: Correct an error condition

### DIFF
--- a/gl4/glBlitFramebuffer.xml
+++ b/gl4/glBlitFramebuffer.xml
@@ -258,9 +258,9 @@
         </para>
         <para>
             <constant>GL_INVALID_OPERATION</constant> is generated if the
-            value of <constant>GL_SAMPLE_BUFFERS</constant> for both read
-            and draw buffers is greater than zero and the dimensions of the
-            source and destination rectangles is not identical.
+            value of <constant>GL_SAMPLE_BUFFERS</constant> for either read or
+            draw buffers is greater than zero and the dimensions of the source
+            and destination rectangles is not identical.
         </para>
         <para>
             <constant>GL_INVALID_FRAMEBUFFER_OPERATION</constant> is


### PR DESCRIPTION
The original extension specification which defines this behavior states that GL_INVALID_OPERATION is generated when SAMPLE_BUFFERS for EITHER the read framebuffer or draw framebuffer is greater than zero. However, the reference page states that GL_INVALID_OPERATION is generated when SAMPLE_BUFFERS for BOTH framebuffers is greater than zero, conflicting with the specification.