### PR TITLE
Fix off-by-one in glGenerateMipMap

### DIFF
--- a/gl4/glGenerateMipmap.xml
+++ b/gl4/glGenerateMipmap.xml
@@ -76,14 +76,14 @@
             Mipmap generation replaces texel image levels $level_{base} + 1$
             through $q$ with images derived from the $level_{base}$ image,
             regardless of their previous contents. All other mimap images,
-            including the $level_{base}+1$ image, are left unchanged by this
+            including the $level_{base}$ image, are left unchanged by this
             computation.
         </para>
         <para>
             The internal formats of the derived mipmap images all match
             those of the $level_{base}$ image. The contents of the derived
             images are computed by repeated, filtered reduction of the
-            $level_{base} + 1$ image. For one- and two-dimensional array and
+            $level_{base}$ image. For one- and two-dimensional array and
             cube map array textures, each layer is filtered independently.
         </para>
     </refsect1>

--- a/gl4/html/glGenerateMipmap.xhtml
+++ b/gl4/html/glGenerateMipmap.xhtml
@@ -107,14 +107,14 @@
             Mipmap generation replaces texel image levels $level_{base} + 1$
             through $q$ with images derived from the $level_{base}$ image,
             regardless of their previous contents. All other mimap images,
-            including the $level_{base}+1$ image, are left unchanged by this
+            including the $level_{base}$ image, are left unchanged by this
             computation.
         </p>
         <p>
             The internal formats of the derived mipmap images all match
             those of the $level_{base}$ image. The contents of the derived
             images are computed by repeated, filtered reduction of the
-            $level_{base} + 1$ image. For one- and two-dimensional array and
+            $level_{base}$ image. For one- and two-dimensional array and
             cube map array textures, each layer is filtered independently.
         </p>
       </div>


### PR DESCRIPTION
Closes #104.

This phrasing is used in the OpenGL 4.6 (section 8.14.4/page 266) and 3.0 (page 212) specifications; this was only a typo in the refpages.

The ES versions did not have this issue, though they _do_ have misleading comments in some places, using the same text for [`base + 1`](https://github.com/KhronosGroup/OpenGL-Refpages/blob/bdf33f8dfeab700ffcae74435b7511bb10d97f21/es3/glGenerateMipmap.xml#L52-L62) and [`base`](https://github.com/KhronosGroup/OpenGL-Refpages/blob/bdf33f8dfeab700ffcae74435b7511bb10d97f21/es3/glGenerateMipmap.xml#L70-L78)). I haven't changed those since I'm not sure why the ES versions don't use the same `$` syntax, and also the comment doesn't end up in the generated HTML.

There are a few other oddities; currently, only [ES 2.0](https://registry.khronos.org/OpenGL-Refpages/es2.0/xhtml/glGenerateMipmap.xml) mentions that "No particular filter algorithm is required" and that `glHint`/`GL_GENERATE_MIPMAP_HINT` exists (later ES versions still mention `GL_GENERATE_MIPMAP_HINT` in `glHint`'s page, but don't have a link from `glGenerateMipmap`, while `GL_GENERATE_MIPMAP_HINT` was deprecated in OpenGL 3.1 but remains in ES from what I can see). I haven't touched those either, but the "No particular filter algorithm is required" was the information I was originally looking for and still is in the OpenGL 4.6 spec.