### PR TITLE
Fix glBindVertexBuffers typo, add zoffset to glCompressedTexSubImage3D

### DIFF
--- a/gl4/glBindVertexBuffers.xml
+++ b/gl4/glBindVertexBuffers.xml
@@ -84,7 +84,7 @@
             </listitem>
         </varlistentry>
         <varlistentry>
-            <term><parameter>buffers</parameter></term>
+            <term><parameter>strides</parameter></term>
             <listitem>
                 <para>
                     Specifies the address of an array of strides to

--- a/gl4/glCompressedTexSubImage3D.xml
+++ b/gl4/glCompressedTexSubImage3D.xml
@@ -106,6 +106,15 @@
       </varlistentry>
 
       <varlistentry>
+        <term><parameter>zoffset</parameter></term>
+
+        <listitem>
+          <para>Specifies a texel offset in the z direction within the texture
+          array.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><parameter>width</parameter></term>
 
         <listitem>

--- a/gl4/html/glBindVertexBuffers.xhtml
+++ b/gl4/html/glBindVertexBuffers.xhtml
@@ -154,7 +154,7 @@
             <dt>
               <span class="term">
                 <em class="parameter">
-                  <code>buffers</code>
+                  <code>strides</code>
                 </em>
               </span>
             </dt>

--- a/gl4/html/glCompressedTexSubImage3D.xhtml
+++ b/gl4/html/glCompressedTexSubImage3D.xhtml
@@ -193,6 +193,17 @@
             <dt>
               <span class="term">
                 <em class="parameter">
+                  <code>zoffset</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>Specifies a texel offset in the z direction within the texture
+          array.</p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
                   <code>width</code>
                 </em>
               </span>


### PR DESCRIPTION
Hello, durning parsing gl4 xml files (for creating opengl C# bindings) I've found several typos/missing parameter descriptions. I've fixed some of them:

- `glBindVertexBuffers` Fix typo: `buffers` -> `strides` https://registry.khronos.org/OpenGL-Refpages/gl4/html/glBindVertexBuffers.xhtml
- `glCompressedTexSubImage3D` Add missing: `zoffset` https://registry.khronos.org/OpenGL-Refpages/gl4/html/glCompressedTexSubImage3D.xhtml (copied from ES3.0 https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glCompressedTexSubImage3D.xhtml where there is parameter description for `zoffset`)

Other things I've noticed but I dont have proper fixes for them:

- `glCopyImageSubData` - Missing `dstlevel` in parameters section https://registry.khronos.org/OpenGL-Refpages/gl4/html/glCopyImageSubData.xhtml
- `glFramebufferTexture` - Missing `layer` in parameters section https://registry.khronos.org/OpenGL-Refpages/gl4/html/glFramebufferTexture.xhtml
- `glGetNamedBufferParameteriv` - Missing `pname` & `params` in parameters section https://registry.khronos.org/OpenGL-Refpages/gl4/html/glGetBufferParameter.xhtml
- `glGetProgramResource` - Only 2 arguments are in parameters section. 6 are missing. https://registry.khronos.org/OpenGL-Refpages/gl4/html/glGetProgramResource.xhtml
- `glTexImage3DMultisample` - Missing `depth` in parameters section https://registry.khronos.org/OpenGL-Refpages/gl4/html/glTexImage3DMultisample.xhtml