### PR TITLE
Removed incorrect 'out' value on 'ldexp'

### DIFF
--- a/gl4/ldexp.xml
+++ b/gl4/ldexp.xml
@@ -42,7 +42,7 @@
             </listitem>
         </varlistentry>
         <varlistentry>
-            <term><parameter>out exp</parameter></term>
+            <term><parameter>exp</parameter></term>
             <listitem>
                 <para>
                     Specifies the value to be used as a source of exponent.


### PR DESCRIPTION
As per #137 

In `ldexp`, the `exp` parameter is not an output, but is listed as such in the parameters list.