### PR TITLE
Fix gl4 documentation for glDrawElements

### DIFF
--- a/es3.1/html/indexflat.php
+++ b/es3.1/html/indexflat.php
@@ -365,8 +365,8 @@
                 <li><a href="glMapBufferRange.xhtml" target="pagedisplay">glMapBufferRange</a></li>
                 <li><a href="matrixCompMult.xhtml" target="pagedisplay">matrixCompMult</a></li>
                 <li><a href="max.xhtml" target="pagedisplay">max</a></li>
-                <li><a href="memoryBarrier.xhtml" target="pagedisplay">memoryBarrier</a></li>
                 <li><a href="glMemoryBarrier.xhtml" target="pagedisplay">glMemoryBarrier</a></li>
+                <li><a href="memoryBarrier.xhtml" target="pagedisplay">memoryBarrier</a></li>
                 <li><a href="memoryBarrierAtomicCounter.xhtml" target="pagedisplay">memoryBarrierAtomicCounter</a></li>
                 <li><a href="memoryBarrierBuffer.xhtml" target="pagedisplay">memoryBarrierBuffer</a></li>
                 <li><a href="glMemoryBarrier.xhtml" target="pagedisplay">glMemoryBarrierByRegion</a></li>

--- a/es3/glDrawElementsBaseVertex.xml
+++ b/es3/glDrawElementsBaseVertex.xml
@@ -65,7 +65,8 @@
             <term><parameter>indices</parameter></term>
             <listitem>
                 <para>
-                    Specifies a pointer to the location where the indices are stored.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <constant>GL_ELEMENT_ARRAY_BUFFER</constant>
+                    to start reading indices from. If no buffer is bound, specifies a pointer to the location where the indices are stored.
                 </para>
             </listitem>
         </varlistentry>

--- a/es3/glDrawElementsInstancedBaseVertex.xml
+++ b/es3/glDrawElementsInstancedBaseVertex.xml
@@ -66,7 +66,8 @@
             <term><parameter>indices</parameter></term>
             <listitem>
                 <para>
-                    Specifies a pointer to the location where the indices are stored.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <constant>GL_ELEMENT_ARRAY_BUFFER</constant>
+                    to start reading indices from. If no buffer is bound, specifies a pointer to the location where the indices are stored.
                 </para>
             </listitem>
         </varlistentry>

--- a/es3/glDrawRangeElementsBaseVertex.xml
+++ b/es3/glDrawRangeElementsBaseVertex.xml
@@ -83,7 +83,8 @@
             <term><parameter>indices</parameter></term>
             <listitem>
                 <para>
-                    Specifies a pointer to the location where the indices are stored.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <constant>GL_ELEMENT_ARRAY_BUFFER</constant>
+                    to start reading indices from. If no buffer is bound, specifies a pointer to the location where the indices are stored.
                 </para>
             </listitem>
         </varlistentry>

--- a/es3/html/glDrawElementsBaseVertex.xhtml
+++ b/es3/html/glDrawElementsBaseVertex.xhtml
@@ -109,7 +109,8 @@
             </dt>
             <dd>
               <p>
-                    Specifies a pointer to the location where the indices are stored.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <code class="constant">GL_ELEMENT_ARRAY_BUFFER</code>
+                    to start reading indices from. If no buffer is bound, specifies a pointer to the location where the indices are stored.
                 </p>
             </dd>
             <dt>

--- a/es3/html/glDrawElementsInstancedBaseVertex.xhtml
+++ b/es3/html/glDrawElementsInstancedBaseVertex.xhtml
@@ -113,7 +113,8 @@
             </dt>
             <dd>
               <p>
-                    Specifies a pointer to the location where the indices are stored.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <code class="constant">GL_ELEMENT_ARRAY_BUFFER</code>
+                    to start reading indices from. If no buffer is bound, specifies a pointer to the location where the indices are stored.
                 </p>
             </dd>
             <dt>

--- a/es3/html/glDrawRangeElementsBaseVertex.xhtml
+++ b/es3/html/glDrawRangeElementsBaseVertex.xhtml
@@ -141,7 +141,8 @@
             </dt>
             <dd>
               <p>
-                    Specifies a pointer to the location where the indices are stored.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <code class="constant">GL_ELEMENT_ARRAY_BUFFER</code>
+                    to start reading indices from. If no buffer is bound, specifies a pointer to the location where the indices are stored.
                 </p>
             </dd>
             <dt>

--- a/es3/html/indexflat.php
+++ b/es3/html/indexflat.php
@@ -422,8 +422,8 @@
                 <li><a href="glMapBufferRange.xhtml" target="pagedisplay">glMapBufferRange</a></li>
                 <li><a href="matrixCompMult.xhtml" target="pagedisplay">matrixCompMult</a></li>
                 <li><a href="max.xhtml" target="pagedisplay">max</a></li>
-                <li><a href="memoryBarrier.xhtml" target="pagedisplay">memoryBarrier</a></li>
                 <li><a href="glMemoryBarrier.xhtml" target="pagedisplay">glMemoryBarrier</a></li>
+                <li><a href="memoryBarrier.xhtml" target="pagedisplay">memoryBarrier</a></li>
                 <li><a href="memoryBarrierAtomicCounter.xhtml" target="pagedisplay">memoryBarrierAtomicCounter</a></li>
                 <li><a href="memoryBarrierBuffer.xhtml" target="pagedisplay">memoryBarrierBuffer</a></li>
                 <li><a href="glMemoryBarrier.xhtml" target="pagedisplay">glMemoryBarrierByRegion</a></li>

--- a/gl4/glDrawElements.xml
+++ b/gl4/glDrawElements.xml
@@ -77,7 +77,8 @@
             <term><parameter>indices</parameter></term>
             <listitem>
                 <para>
-                    Specifies a pointer to the location where the indices are stored.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <constant>GL_ELEMENT_ARRAY_BUFFER</constant>
+                    to start reading indices from.
                 </para>
             </listitem>
         </varlistentry>

--- a/gl4/glDrawElementsBaseVertex.xml
+++ b/gl4/glDrawElementsBaseVertex.xml
@@ -65,7 +65,8 @@
             <term><parameter>indices</parameter></term>
             <listitem>
                 <para>
-                    Specifies a pointer to the location where the indices are stored.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <constant>GL_ELEMENT_ARRAY_BUFFER</constant>
+                    to start reading indices from.
                 </para>
             </listitem>
         </varlistentry>

--- a/gl4/glDrawElementsInstanced.xml
+++ b/gl4/glDrawElementsInstanced.xml
@@ -73,7 +73,8 @@
             <term><parameter>indices</parameter></term>
             <listitem>
                 <para>
-                    Specifies a pointer to the location where the indices are stored.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <constant>GL_ELEMENT_ARRAY_BUFFER</constant>
+                    to start reading indices from.
                 </para>
             </listitem>
         </varlistentry>

--- a/gl4/glDrawElementsInstancedBaseInstance.xml
+++ b/gl4/glDrawElementsInstancedBaseInstance.xml
@@ -74,7 +74,8 @@
             <term><parameter>indices</parameter></term>
             <listitem>
                 <para>
-                    Specifies a pointer to the location where the indices are stored.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <constant>GL_ELEMENT_ARRAY_BUFFER</constant>
+                    to start reading indices from.
                 </para>
             </listitem>
         </varlistentry>

--- a/gl4/glDrawElementsInstancedBaseVertex.xml
+++ b/gl4/glDrawElementsInstancedBaseVertex.xml
@@ -66,7 +66,8 @@
             <term><parameter>indices</parameter></term>
             <listitem>
                 <para>
-                    Specifies a pointer to the location where the indices are stored.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <constant>GL_ELEMENT_ARRAY_BUFFER</constant>
+                    to start reading indices from.
                 </para>
             </listitem>
         </varlistentry>

--- a/gl4/glDrawElementsInstancedBaseVertexBaseInstance.xml
+++ b/gl4/glDrawElementsInstancedBaseVertexBaseInstance.xml
@@ -67,7 +67,8 @@
             <term><parameter>indices</parameter></term>
             <listitem>
                 <para>
-                    Specifies a pointer to the location where the indices are stored.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <constant>GL_ELEMENT_ARRAY_BUFFER</constant>
+                    to start reading indices from.
                 </para>
             </listitem>
         </varlistentry>

--- a/gl4/glDrawRangeElements.xml
+++ b/gl4/glDrawRangeElements.xml
@@ -95,7 +95,8 @@
             <term><parameter>indices</parameter></term>
             <listitem>
                 <para>
-                    Specifies a pointer to the location where the indices are stored.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <constant>GL_ELEMENT_ARRAY_BUFFER</constant>
+                    to start reading indices from.
                 </para>
             </listitem>
         </varlistentry>

--- a/gl4/glDrawRangeElementsBaseVertex.xml
+++ b/gl4/glDrawRangeElementsBaseVertex.xml
@@ -83,7 +83,8 @@
             <term><parameter>indices</parameter></term>
             <listitem>
                 <para>
-                    Specifies a pointer to the location where the indices are stored.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <constant>GL_ELEMENT_ARRAY_BUFFER</constant>
+                    to start reading indices from.
                 </para>
             </listitem>
         </varlistentry>

--- a/gl4/glMultiDrawElements.xml
+++ b/gl4/glMultiDrawElements.xml
@@ -74,7 +74,8 @@
             <term><parameter>indices</parameter></term>
             <listitem>
                 <para>
-                    Specifies a pointer to the location where the indices are stored.
+                    Points to an array of byte offsets (cast to a pointer type) into the buffer bound to <constant>GL_ELEMENT_ARRAY_BUFFER</constant>
+                    to start reading indices from.
                 </para>
             </listitem>
         </varlistentry>

--- a/gl4/glMultiDrawElementsBaseVertex.xml
+++ b/gl4/glMultiDrawElementsBaseVertex.xml
@@ -75,7 +75,8 @@
             <term><parameter>indices</parameter></term>
             <listitem>
                 <para>
-                    Specifies a pointer to the location where the indices are stored.
+                    Points to an array of byte offsets (cast to a pointer type) into the buffer bound to <constant>GL_ELEMENT_ARRAY_BUFFER</constant>
+                    to start reading indices from.
                 </para>
             </listitem>
         </varlistentry>

--- a/gl4/html/glDrawElements.xhtml
+++ b/gl4/html/glDrawElements.xhtml
@@ -114,7 +114,8 @@
             </dt>
             <dd>
               <p>
-                    Specifies a pointer to the location where the indices are stored.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <code class="constant">GL_ELEMENT_ARRAY_BUFFER</code>
+                    to start reading indices from.
                 </p>
             </dd>
           </dl>

--- a/gl4/html/glDrawElementsBaseVertex.xhtml
+++ b/gl4/html/glDrawElementsBaseVertex.xhtml
@@ -109,7 +109,8 @@
             </dt>
             <dd>
               <p>
-                    Specifies a pointer to the location where the indices are stored.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <code class="constant">GL_ELEMENT_ARRAY_BUFFER</code>
+                    to start reading indices from.
                 </p>
             </dd>
             <dt>

--- a/gl4/html/glDrawElementsInstanced.xhtml
+++ b/gl4/html/glDrawElementsInstanced.xhtml
@@ -117,7 +117,8 @@
             </dt>
             <dd>
               <p>
-                    Specifies a pointer to the location where the indices are stored.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <code class="constant">GL_ELEMENT_ARRAY_BUFFER</code>
+                    to start reading indices from.
                 </p>
             </dd>
             <dt>

--- a/gl4/html/glDrawElementsInstancedBaseInstance.xhtml
+++ b/gl4/html/glDrawElementsInstancedBaseInstance.xhtml
@@ -121,7 +121,8 @@
             </dt>
             <dd>
               <p>
-                    Specifies a pointer to the location where the indices are stored.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <code class="constant">GL_ELEMENT_ARRAY_BUFFER</code>
+                    to start reading indices from.
                 </p>
             </dd>
             <dt>

--- a/gl4/html/glDrawElementsInstancedBaseVertex.xhtml
+++ b/gl4/html/glDrawElementsInstancedBaseVertex.xhtml
@@ -113,7 +113,8 @@
             </dt>
             <dd>
               <p>
-                    Specifies a pointer to the location where the indices are stored.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <code class="constant">GL_ELEMENT_ARRAY_BUFFER</code>
+                    to start reading indices from.
                 </p>
             </dd>
             <dt>

--- a/gl4/html/glDrawElementsInstancedBaseVertexBaseInstance.xhtml
+++ b/gl4/html/glDrawElementsInstancedBaseVertexBaseInstance.xhtml
@@ -117,7 +117,8 @@
             </dt>
             <dd>
               <p>
-                    Specifies a pointer to the location where the indices are stored.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <code class="constant">GL_ELEMENT_ARRAY_BUFFER</code>
+                    to start reading indices from.
                 </p>
             </dd>
             <dt>

--- a/gl4/html/glDrawRangeElements.xhtml
+++ b/gl4/html/glDrawRangeElements.xhtml
@@ -146,7 +146,8 @@
             </dt>
             <dd>
               <p>
-                    Specifies a pointer to the location where the indices are stored.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <code class="constant">GL_ELEMENT_ARRAY_BUFFER</code>
+                    to start reading indices from.
                 </p>
             </dd>
           </dl>

--- a/gl4/html/glDrawRangeElementsBaseVertex.xhtml
+++ b/gl4/html/glDrawRangeElementsBaseVertex.xhtml
@@ -141,7 +141,8 @@
             </dt>
             <dd>
               <p>
-                    Specifies a pointer to the location where the indices are stored.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <code class="constant">GL_ELEMENT_ARRAY_BUFFER</code>
+                    to start reading indices from.
                 </p>
             </dd>
             <dt>

--- a/gl4/html/glMultiDrawElements.xhtml
+++ b/gl4/html/glMultiDrawElements.xhtml
@@ -118,7 +118,8 @@
             </dt>
             <dd>
               <p>
-                    Specifies a pointer to the location where the indices are stored.
+                    Points to an array of byte offsets (cast to a pointer type) into the buffer bound to <code class="constant">GL_ELEMENT_ARRAY_BUFFER</code>
+                    to start reading indices from.
                 </p>
             </dd>
             <dt>

--- a/gl4/html/glMultiDrawElementsBaseVertex.xhtml
+++ b/gl4/html/glMultiDrawElementsBaseVertex.xhtml
@@ -122,7 +122,8 @@
             </dt>
             <dd>
               <p>
-                    Specifies a pointer to the location where the indices are stored.
+                    Points to an array of byte offsets (cast to a pointer type) into the buffer bound to <code class="constant">GL_ELEMENT_ARRAY_BUFFER</code>
+                    to start reading indices from.
                 </p>
             </dd>
             <dt>

--- a/gl4/html/indexflat.php
+++ b/gl4/html/indexflat.php
@@ -582,8 +582,8 @@
                 <li><a href="glMapBufferRange.xhtml" target="pagedisplay">glMapNamedBufferRange</a></li>
                 <li><a href="matrixCompMult.xhtml" target="pagedisplay">matrixCompMult</a></li>
                 <li><a href="max.xhtml" target="pagedisplay">max</a></li>
-                <li><a href="memoryBarrier.xhtml" target="pagedisplay">memoryBarrier</a></li>
                 <li><a href="glMemoryBarrier.xhtml" target="pagedisplay">glMemoryBarrier</a></li>
+                <li><a href="memoryBarrier.xhtml" target="pagedisplay">memoryBarrier</a></li>
                 <li><a href="memoryBarrierAtomicCounter.xhtml" target="pagedisplay">memoryBarrierAtomicCounter</a></li>
                 <li><a href="memoryBarrierBuffer.xhtml" target="pagedisplay">memoryBarrierBuffer</a></li>
                 <li><a href="glMemoryBarrier.xhtml" target="pagedisplay">glMemoryBarrierByRegion</a></li>


### PR DESCRIPTION
Fixes the documentation for the `indices` parameter so that correctly documents OpenGL 4 behavior for the following functions:
- `glDrawElements`
- `glDrawElementsInstanced`
- `glDrawElementsBaseVertex`
- `glDrawElementsInstancedBaseVertex`
- `glDrawElementsInstancedBaseVertexBaseInstance`
- `glDrawRangeElements`
- `glDrawRangeElementsBaseVertex`
- `glMultiDrawRangeElements`
- `glMultiDrawRangeElementsBaseVertex`

Does the same for the following ES3.2 functions:
- `glDrawElementsBaseVertex`
- `glDrawElementsInstancedBaseVertex`
- `glDrawRangeElementsBaseVertex`

Fixes #82 

Works when I build it locally
![image](https://github.com/KhronosGroup/OpenGL-Refpages/assets/3778357/44803dce-4abf-42ea-acc0-1aebd7ceea45)