### PR TITLE
Add GL_VERTEX_BINDING_BUFFER to es3 and es3.1 documentation.

### DIFF
--- a/es3.1/glGet.xml
+++ b/es3.1/glGet.xml
@@ -2261,6 +2261,15 @@
                 </listitem>
             </varlistentry>
             <varlistentry>
+                <term><constant>GL_VERTEX_BINDING_BUFFER</constant></term>
+                <listitem>
+                    <para>
+                        Accepted by the indexed forms. <parameter>data</parameter> returns a single integer value representing the name of the buffer
+                        bound to vertex binding <parameter>index</parameter>.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
                 <term><constant>GL_VIEWPORT</constant></term>
                 <listitem>
                     <para>

--- a/es3.1/html/glGet.xhtml
+++ b/es3.1/html/glGet.xhtml
@@ -2740,6 +2740,17 @@
             </dd>
             <dt>
               <span class="term">
+                <code class="constant">GL_VERTEX_BINDING_BUFFER</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                        Accepted by the indexed forms. <em class="parameter"><code>data</code></em> returns a single integer value representing the name of the buffer
+                        bound to vertex binding <em class="parameter"><code>index</code></em>.
+                    </p>
+            </dd>
+            <dt>
+              <span class="term">
                 <code class="constant">GL_VIEWPORT</code>
               </span>
             </dt>

--- a/es3.1/html/indexflat.php
+++ b/es3.1/html/indexflat.php
@@ -365,8 +365,8 @@
                 <li><a href="glMapBufferRange.xhtml" target="pagedisplay">glMapBufferRange</a></li>
                 <li><a href="matrixCompMult.xhtml" target="pagedisplay">matrixCompMult</a></li>
                 <li><a href="max.xhtml" target="pagedisplay">max</a></li>
-                <li><a href="memoryBarrier.xhtml" target="pagedisplay">memoryBarrier</a></li>
                 <li><a href="glMemoryBarrier.xhtml" target="pagedisplay">glMemoryBarrier</a></li>
+                <li><a href="memoryBarrier.xhtml" target="pagedisplay">memoryBarrier</a></li>
                 <li><a href="memoryBarrierAtomicCounter.xhtml" target="pagedisplay">memoryBarrierAtomicCounter</a></li>
                 <li><a href="memoryBarrierBuffer.xhtml" target="pagedisplay">memoryBarrierBuffer</a></li>
                 <li><a href="glMemoryBarrier.xhtml" target="pagedisplay">glMemoryBarrierByRegion</a></li>

--- a/es3/glGet.xml
+++ b/es3/glGet.xml
@@ -2903,6 +2903,15 @@
                 </listitem>
             </varlistentry>
             <varlistentry>
+                <term><constant>GL_VERTEX_BINDING_BUFFER</constant></term>
+                <listitem>
+                    <para>
+                        Accepted by the indexed forms. <parameter>data</parameter> returns a single integer value representing the name of the buffer
+                        bound to vertex binding <parameter>index</parameter>.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
                 <term><constant>GL_VIEWPORT</constant></term>
                 <listitem>
                     <para>

--- a/es3/html/glGet.xhtml
+++ b/es3/html/glGet.xhtml
@@ -3512,6 +3512,17 @@
             </dd>
             <dt>
               <span class="term">
+                <code class="constant">GL_VERTEX_BINDING_BUFFER</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                        Accepted by the indexed forms. <em class="parameter"><code>data</code></em> returns a single integer value representing the name of the buffer
+                        bound to vertex binding <em class="parameter"><code>index</code></em>.
+                    </p>
+            </dd>
+            <dt>
+              <span class="term">
                 <code class="constant">GL_VIEWPORT</code>
               </span>
             </dt>

--- a/es3/html/indexflat.php
+++ b/es3/html/indexflat.php
@@ -422,8 +422,8 @@
                 <li><a href="glMapBufferRange.xhtml" target="pagedisplay">glMapBufferRange</a></li>
                 <li><a href="matrixCompMult.xhtml" target="pagedisplay">matrixCompMult</a></li>
                 <li><a href="max.xhtml" target="pagedisplay">max</a></li>
-                <li><a href="memoryBarrier.xhtml" target="pagedisplay">memoryBarrier</a></li>
                 <li><a href="glMemoryBarrier.xhtml" target="pagedisplay">glMemoryBarrier</a></li>
+                <li><a href="memoryBarrier.xhtml" target="pagedisplay">memoryBarrier</a></li>
                 <li><a href="memoryBarrierAtomicCounter.xhtml" target="pagedisplay">memoryBarrierAtomicCounter</a></li>
                 <li><a href="memoryBarrierBuffer.xhtml" target="pagedisplay">memoryBarrierBuffer</a></li>
                 <li><a href="glMemoryBarrier.xhtml" target="pagedisplay">glMemoryBarrierByRegion</a></li>

--- a/gl4/html/indexflat.php
+++ b/gl4/html/indexflat.php
@@ -582,8 +582,8 @@
                 <li><a href="glMapBufferRange.xhtml" target="pagedisplay">glMapNamedBufferRange</a></li>
                 <li><a href="matrixCompMult.xhtml" target="pagedisplay">matrixCompMult</a></li>
                 <li><a href="max.xhtml" target="pagedisplay">max</a></li>
-                <li><a href="memoryBarrier.xhtml" target="pagedisplay">memoryBarrier</a></li>
                 <li><a href="glMemoryBarrier.xhtml" target="pagedisplay">glMemoryBarrier</a></li>
+                <li><a href="memoryBarrier.xhtml" target="pagedisplay">memoryBarrier</a></li>
                 <li><a href="memoryBarrierAtomicCounter.xhtml" target="pagedisplay">memoryBarrierAtomicCounter</a></li>
                 <li><a href="memoryBarrierBuffer.xhtml" target="pagedisplay">memoryBarrierBuffer</a></li>
                 <li><a href="glMemoryBarrier.xhtml" target="pagedisplay">glMemoryBarrierByRegion</a></li>


### PR DESCRIPTION
This should fix the remaining parts of #54 to my knowledge.
The constants `GL_VERTEX_BINDING_BUFFER` and `GL_VERTEX_ATTRIB_BINDING` do not exist in the OpenGL 2.1 spec so it shouldn't be added to that api.

Fixes #54 