### PR TITLE
gl4/atomicCompSwap: fix typo in arguments type (uint->int)

### DIFF
--- a/gl4/atomicCompSwap.xml
+++ b/gl4/atomicCompSwap.xml
@@ -22,8 +22,8 @@
             <funcprototype>
                 <funcdef>int <function>atomicCompSwap</function></funcdef>
                 <paramdef>inout int <parameter>mem</parameter></paramdef>
-                <paramdef>uint <parameter>compare</parameter></paramdef>
-                <paramdef>uint <parameter>data</parameter></paramdef>
+                <paramdef>int <parameter>compare</parameter></paramdef>
+                <paramdef>int <parameter>data</parameter></paramdef>
             </funcprototype>
             <funcprototype>
                 <funcdef>uint <function>atomicCompSwap</function></funcdef>


### PR DESCRIPTION
Hi!

https://registry.khronos.org/OpenGL-Refpages/gl4/html/atomicCompSwap.xhtml

Fixed typo in atomicCompSwap-overload for int type.