### PR TITLE
Fix typo in packUnorm.xml

### DIFF
--- a/gl4/packUnorm.xml
+++ b/gl4/packUnorm.xml
@@ -52,8 +52,8 @@
     <refsect1 xml:id="description"><title>Description</title>
         <para>
             <function>packUnorm2x16</function>, <function>packSnorm2x16</function>, <function>packUnorm4x8</function> and <function>packSnorm4x8</function> convert
-            each component of the normalized floating-ponit value <parameter>v</parameter> into 8- or 16-bit integer
-            values and then packs the results into a 32-bit unsigned intgeter.
+            each component of the normalized floating-point value <parameter>v</parameter> into 8- or 16-bit integer
+            values and then packs the results into a 32-bit unsigned integer.
         </para>
         <para>
             The conversion for component <parameter>c</parameter> of <parameter>v</parameter> to fixed-point is


### PR DESCRIPTION
Hello!

While consulting the reference for packUnorm I found a couple of small typos in the documentation.