### PR TITLE
Add MacOSX instructions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -37,7 +37,9 @@ Tools you'll need to build include:
 If you're using Ubuntu, or the Windows 10 Ubuntu subsystem, the required
 package names are probably basically the same as Debian.
 
-It's possible to build the ref pages on Mac OS X and Cygwin, but we
+On MacOSx, you can install 'docbook' and 'docbook-xls' from homebrew. In order to view equations correctly, you can copy the Docbook MathML module into the subdirectories for the OpenGL versions. xsltproc should be on your system, but you may need to install 'xcode-tools'.
+
+It's possible to build the ref pages on Cygwin, but we
 don't have current package names or instructions for those environments.
 If you do, please submit a pull request adding details to this README.
 


### PR DESCRIPTION
Hi, I've added some instructions for MacOSX. 

Everything seems to work fine, except for es3.1, which gives the following error:
```
cd html ; /Applications/Xcode.app/Contents/Developer/usr/bin/make default
xsltproc --nonet --xinclude --noout opengl-man.xsl ../glActiveShaderProgram.xml
I/O error : Attempt to load network entity http://docbook.sourceforge.net/release/xsl-ns/current/xhtml5/onechunk.xsl
warning: failed to load external entity "http://docbook.sourceforge.net/release/xsl-ns/current/xhtml5/onechunk.xsl"
compilation error: file opengl-man.xsl line 6 element import
xsl:import : unable to load http://docbook.sourceforge.net/release/xsl-ns/current/xhtml5/onechunk.xsl
make[2]: *** [glActiveShaderProgram.xhtml] Error 5
make[1]: *** [default] Error 2
```
But otherwise, things seem to work correctly when you run `php -S 127.0.0.1:8000` in the subdirectories.