### PR TITLE
Update gl4/equal.xml: Fix wrong argument name (typo)

### DIFF
--- a/gl4/equal.xml
+++ b/gl4/equal.xml
@@ -47,7 +47,7 @@
             </listitem>
         </varlistentry>
         <varlistentry>
-            <term><parameter>x</parameter></term>
+            <term><parameter>y</parameter></term>
             <listitem>
                 <para>
                     Specifies the second vector to be used in the comparison operation.


### PR DESCRIPTION
Edited only the XML - HTML must be regenerated after, I guess.

https://github.com/KhronosGroup/OpenGL-Refpages/blob/325d0438fb3532f229de76574adc679bd35acf7f/gl4/equal.xml#L50-L54
https://github.com/KhronosGroup/OpenGL-Refpages/blob/325d0438fb3532f229de76574adc679bd35acf7f/gl4/html/equal.xhtml#L90