### PR TITLE
Fix copy paste error in glMemoryBarrier.xml

### DIFF
--- a/gl4/glMemoryBarrier.xml
+++ b/gl4/glMemoryBarrier.xml
@@ -55,7 +55,7 @@
                     <constant>GL_SHADER_STORAGE_BARRIER_BIT</constant>.
                 </para>
                 <para>
-                    For <function>glMemoryBarrier</function>, must be a
+                    For <function>glMemoryBarrierByRegion</function>, must be a
                     bitwise combination of any of
                     <constant>GL_ATOMIC_COUNTER_BARRIER_BIT</constant>, or
                     <constant>GL_FRAMEBUFFER_BARRIER_BIT</constant>,

--- a/gl4/html/glMemoryBarrier.xhtml
+++ b/gl4/html/glMemoryBarrier.xhtml
@@ -80,7 +80,7 @@
                     <code class="constant">GL_SHADER_STORAGE_BARRIER_BIT</code>.
                 </p>
               <p>
-                    For <code class="function">glMemoryBarrier</code>, must be a
+                    For <code class="function">glMemoryBarrierByRegion</code>, must be a
                     bitwise combination of any of
                     <code class="constant">GL_ATOMIC_COUNTER_BARRIER_BIT</code>, or
                     <code class="constant">GL_FRAMEBUFFER_BARRIER_BIT</code>,


### PR DESCRIPTION
After being confused by the `Parameters` Section of  https://registry.khronos.org/OpenGL-Refpages/gl4/html/glMemoryBarrier.xhtml I noticed that `glMemoryBarrier` appears twice, and `glMemoryBarrierByRegion` isn't mentioned at all. This looks to be an error from copying the entire section.