### PR TITLE
Correct spelling of 'except'.

### DIFF
--- a/gl4/glDrawElementsIndirect.xml
+++ b/gl4/glDrawElementsIndirect.xml
@@ -76,7 +76,7 @@
             <function>glDrawElementsIndirect</function> specifies multiple indexed geometric primitives
             with very few subroutine calls. <function>glDrawElementsIndirect</function> behaves
             similarly to <citerefentry><refentrytitle>glDrawElementsInstancedBaseVertexBaseInstance</refentrytitle></citerefentry>,
-            execpt that the parameters to <citerefentry><refentrytitle>glDrawElementsInstancedBaseVertexBaseInstance</refentrytitle></citerefentry>
+            except that the parameters to <citerefentry><refentrytitle>glDrawElementsInstancedBaseVertexBaseInstance</refentrytitle></citerefentry>
             are stored in memory at the address given by <parameter>indirect</parameter>.
         </para>
         <para>

--- a/gl4/glMultiDrawElementsIndirect.xml
+++ b/gl4/glMultiDrawElementsIndirect.xml
@@ -95,7 +95,7 @@
             <function>glMultiDrawElementsIndirect</function> specifies multiple indexed geometric primitives
             with very few subroutine calls. <function>glMultiDrawElementsIndirect</function> behaves
             similarly to a multitude of calls to <citerefentry><refentrytitle>glDrawElementsInstancedBaseVertexBaseInstance</refentrytitle></citerefentry>,
-            execpt that the parameters to <citerefentry><refentrytitle>glDrawElementsInstancedBaseVertexBaseInstance</refentrytitle></citerefentry>
+            except that the parameters to <citerefentry><refentrytitle>glDrawElementsInstancedBaseVertexBaseInstance</refentrytitle></citerefentry>
             are stored in an array in memory at the address given by <parameter>indirect</parameter>, separated
             by the stride, in basic machine units, specified by <parameter>stride</parameter>. If <parameter>stride</parameter>
             is zero, then the array is assumed to be tightly packed in memory.

--- a/gl4/html/glDrawElementsIndirect.xhtml
+++ b/gl4/html/glDrawElementsIndirect.xhtml
@@ -110,7 +110,7 @@
             <code class="function">glDrawElementsIndirect</code> specifies multiple indexed geometric primitives
             with very few subroutine calls. <code class="function">glDrawElementsIndirect</code> behaves
             similarly to <a class="citerefentry" href="glDrawElementsInstancedBaseVertexBaseInstance.xhtml"><span class="citerefentry"><span class="refentrytitle">glDrawElementsInstancedBaseVertexBaseInstance</span></span></a>,
-            execpt that the parameters to <a class="citerefentry" href="glDrawElementsInstancedBaseVertexBaseInstance.xhtml"><span class="citerefentry"><span class="refentrytitle">glDrawElementsInstancedBaseVertexBaseInstance</span></span></a>
+            except that the parameters to <a class="citerefentry" href="glDrawElementsInstancedBaseVertexBaseInstance.xhtml"><span class="citerefentry"><span class="refentrytitle">glDrawElementsInstancedBaseVertexBaseInstance</span></span></a>
             are stored in memory at the address given by <em class="parameter"><code>indirect</code></em>.
         </p>
         <p>

--- a/gl4/html/glMultiDrawElementsIndirect.xhtml
+++ b/gl4/html/glMultiDrawElementsIndirect.xhtml
@@ -144,7 +144,7 @@
             <code class="function">glMultiDrawElementsIndirect</code> specifies multiple indexed geometric primitives
             with very few subroutine calls. <code class="function">glMultiDrawElementsIndirect</code> behaves
             similarly to a multitude of calls to <a class="citerefentry" href="glDrawElementsInstancedBaseVertexBaseInstance.xhtml"><span class="citerefentry"><span class="refentrytitle">glDrawElementsInstancedBaseVertexBaseInstance</span></span></a>,
-            execpt that the parameters to <a class="citerefentry" href="glDrawElementsInstancedBaseVertexBaseInstance.xhtml"><span class="citerefentry"><span class="refentrytitle">glDrawElementsInstancedBaseVertexBaseInstance</span></span></a>
+            except that the parameters to <a class="citerefentry" href="glDrawElementsInstancedBaseVertexBaseInstance.xhtml"><span class="citerefentry"><span class="refentrytitle">glDrawElementsInstancedBaseVertexBaseInstance</span></span></a>
             are stored in an array in memory at the address given by <em class="parameter"><code>indirect</code></em>, separated
             by the stride, in basic machine units, specified by <em class="parameter"><code>stride</code></em>. If <em class="parameter"><code>stride</code></em>
             is zero, then the array is assumed to be tightly packed in memory.


### PR DESCRIPTION
's/execpt/except/'