### PR TITLE
Fix inverted GL version requirements on `glBlendFunc()` and `glBlendFuncSeparate()` pages (2.1)

### DIFF
--- a/gl2.1/glBlendFunc.xml
+++ b/gl2.1/glBlendFunc.xml
@@ -1199,12 +1199,12 @@
             supported by your implementation.
         </para>
         <para>
-            <constant>GL_SRC_COLOR</constant> and <constant>GL_ONE_MINUS_SRC_COLOR</constant> are valid only for
-            <parameter>sfactor</parameter> if the GL version is 1.4 or greater.
+            <constant>GL_SRC_COLOR</constant> and <constant>GL_ONE_MINUS_SRC_COLOR</constant> are valid for
+            <parameter>sfactor</parameter> only if the GL version is 1.4 or greater.
         </para>
         <para>
-            <constant>GL_DST_COLOR</constant> and <constant>GL_ONE_MINUS_DST_COLOR</constant> are valid only for
-            <parameter>dfactor</parameter> if the GL version is 1.4 or greater.
+            <constant>GL_DST_COLOR</constant> and <constant>GL_ONE_MINUS_DST_COLOR</constant> are valid for
+            <parameter>dfactor</parameter> only if the GL version is 1.4 or greater.
         </para>
     </refsect1>
     <refsect1 id="errors"><title>Errors</title>

--- a/gl2.1/glBlendFuncSeparate.xml
+++ b/gl2.1/glBlendFuncSeparate.xml
@@ -1253,12 +1253,12 @@
             supported by your implementation.
         </para>
         <para>
-            <constant>GL_SRC_COLOR</constant> and <constant>GL_ONE_MINUS_SRC_COLOR</constant> are valid only for
-            <parameter>srcRGB</parameter> if the GL version is 1.4 or greater.
+            <constant>GL_SRC_COLOR</constant> and <constant>GL_ONE_MINUS_SRC_COLOR</constant> are valid for
+            <parameter>srcRGB</parameter> only if the GL version is 1.4 or greater.
         </para>
         <para>
-            <constant>GL_DST_COLOR</constant> and <constant>GL_ONE_MINUS_DST_COLOR</constant> are valid only for
-            <parameter>dstRGB</parameter> if the GL version is 1.4 or greater.
+            <constant>GL_DST_COLOR</constant> and <constant>GL_ONE_MINUS_DST_COLOR</constant> are valid for
+            <parameter>dstRGB</parameter> only if the GL version is 1.4 or greater.
         </para>
     </refsect1>
     <refsect1 id="errors"><title>Errors</title>


### PR DESCRIPTION
The current wording sounds like the values are acceptable only for one of the parameters if the GL version is 1.4 or higher. But it's actually the opposite - see the OpenGL 1.4 specification, chapter G "Version 1.4", section G.2 "Blend Squaring" ([`glspec14.pdf`](https://registry.khronos.org/OpenGL/specs/gl/glspec14.pdf), page 290).